### PR TITLE
Don't let imported contracts be created for below the league minimum, an...

### DIFF
--- a/js/core/league.js
+++ b/js/core/league.js
@@ -304,6 +304,9 @@ define(["dao", "db", "globals", "ui", "core/draft", "core/finances", "core/phase
 
                         p = player.augmentPartialPlayer(p, scoutingRank);
 
+                        // Don't let imported contracts be created for below the league minimum, and round to nearest $10,000.
+                        p.contract.amount = Math.max(10 * helpers.round(p.contract.amount / 10), g.minContract);
+
                         // Separate out stats
                         playerStats = p.stats;
                         delete p.stats;


### PR DESCRIPTION
*...d round to nearest $10,000.*

I saw alexnoob released new rosters on reddit so I wanted to get this in, as it fixes two issues that I first noticed using his earlier versions:

1. **Players that have contracts below the league minimum**, this leads to weird issues in FA where over-the-cap teams can sign players for $500k but not $440k.  I could have changed the logic behind signings to allow for anything at or below league minimum, instead of just equal to league minimum, and that may be worth doing as well; but I thought it made sense to clean the data at the source in any event.

2. **Contract values are rounded to $1000s instead of $10,000s.**  Since we're usually rounding this value  this stays mostly hidden, however, it can lead to some odd things. For example, being unable to sign a player that apparently would put you right at the cap because when summing player contracts to get the team payroll the contract amounts aren't rounded. (so a deal that looks like its putting you exactly at the cap could be putting you a couple thousand over)  