### PR TITLE
adds EWA to draft summary

### DIFF
--- a/js/views/draftSummary.js
+++ b/js/views/draftSummary.js
@@ -55,7 +55,7 @@ define(["dao", "globals", "ui", "core/player", "lib/jquery", "lib/knockout", "li
             playersAll = player.filter(playersAll, {
                 attrs: ["tid", "abbrev", "draft", "pid", "name", "pos", "age"],
                 ratings: ["ovr", "pot", "skills"],
-                stats: ["gp", "min", "pts", "trb", "ast", "per"],
+                stats: ["gp", "min", "pts", "trb", "ast", "per", "ewa"],
                 showNoStats: true,
                 showRookies: true,
                 fuzz: true
@@ -104,7 +104,7 @@ define(["dao", "globals", "ui", "core/player", "lib/jquery", "lib/knockout", "li
             var season;
             season = vm.season();
             ui.datatableSinglePage($("#draft-results"), 0, _.map(vm.players(), function (p) {
-                return [p.draft.round + '-' + p.draft.pick, '<a href="' + helpers.leagueUrl(["player", p.pid]) + '">' + p.name + '</a>', p.pos, helpers.draftAbbrev(p.draft.tid, p.draft.originalTid, season), String(p.draft.age), String(p.draft.ovr), String(p.draft.pot), '<span class="skills-alone">' + helpers.skillsBlock(p.draft.skills) + '</span>', '<a href="' + helpers.leagueUrl(["roster", p.currentAbbrev]) + '">' + p.currentAbbrev + '</a>', String(p.currentAge), String(p.currentOvr), String(p.currentPot), '<span class="skills-alone">' + helpers.skillsBlock(p.currentSkills) + '</span>', helpers.round(p.careerStats.gp), helpers.round(p.careerStats.min, 1), helpers.round(p.careerStats.pts, 1), helpers.round(p.careerStats.trb, 1), helpers.round(p.careerStats.ast, 1), helpers.round(p.careerStats.per, 1)];
+                return [p.draft.round + '-' + p.draft.pick, '<a href="' + helpers.leagueUrl(["player", p.pid]) + '">' + p.name + '</a>', p.pos, helpers.draftAbbrev(p.draft.tid, p.draft.originalTid, season), String(p.draft.age), String(p.draft.ovr), String(p.draft.pot), '<span class="skills-alone">' + helpers.skillsBlock(p.draft.skills) + '</span>', '<a href="' + helpers.leagueUrl(["roster", p.currentAbbrev]) + '">' + p.currentAbbrev + '</a>', String(p.currentAge), String(p.currentOvr), String(p.currentPot), '<span class="skills-alone">' + helpers.skillsBlock(p.currentSkills) + '</span>', helpers.round(p.careerStats.gp), helpers.round(p.careerStats.min, 1), helpers.round(p.careerStats.pts, 1), helpers.round(p.careerStats.trb, 1), helpers.round(p.careerStats.ast, 1), helpers.round(p.careerStats.per, 1), helpers.round(p.careerStats.ewa, 1)];
             }));
         }).extend({throttle: 1});
 

--- a/templates/draftSummary.html
+++ b/templates/draftSummary.html
@@ -6,8 +6,8 @@
 <div class="table-responsive">
   <table class="table table-striped table-bordered table-condensed" id="draft-results">
     <thead>
-      <tr><th colspan="3"></th><th colspan="5" style="text-align: center">At Draft</th><th colspan="5" style="text-align: center">Current</th><th colspan="6" style="text-align: center">Career Stats</th></tr>
-      <tr><th>Pick</th><th>Name</th><th title="Position">Pos</th><th>Team</th><th>Age</th><th title="Overall rating">Ovr</th><th title="Potential rating">Pot</th><th>Skills</th><th>Team</th><th>Age</th><th title="Overall rating">Ovr</th><th title="Potential rating">Pot</th><th>Skills</th><th title="Games Played">GP</th><th title="Minutes Per Game">Min</th><th title="Points Per Game">PPG</th><th title="Rebounds Per Game">Reb</th><th title="Assists Per Game">Ast</th><th title="Player Efficiency Rating">PER</th></tr>
+      <tr><th colspan="3"></th><th colspan="5" style="text-align: center">At Draft</th><th colspan="5" style="text-align: center">Current</th><th colspan="7" style="text-align: center">Career Stats</th></tr>
+      <tr><th>Pick</th><th>Name</th><th title="Position">Pos</th><th>Team</th><th>Age</th><th title="Overall rating">Ovr</th><th title="Potential rating">Pot</th><th>Skills</th><th>Team</th><th>Age</th><th title="Overall rating">Ovr</th><th title="Potential rating">Pot</th><th>Skills</th><th title="Games Played">GP</th><th title="Minutes Per Game">Min</th><th title="Points Per Game">PPG</th><th title="Rebounds Per Game">Reb</th><th title="Assists Per Game">Ast</th><th title="Player Efficiency Rating">PER</th><th title="Estimated Wins Added">EWA</th></tr>
     </thead>
   </table>
 </div>


### PR DESCRIPTION
This is one I noticed I really missed when playing.  The other screens where I might be comparing players over a career (Team History, HoF) have EWA but the draft summary has only per game averages and PER.  Adding EWA gives the draft summary grid a nice "total" stat to give an overall comparison when trying to go back and review a prior season's draft class.