### PR TITLE
Trade feedback

### DIFF
--- a/js/core/trade.js
+++ b/js/core/trade.js
@@ -278,7 +278,6 @@ define(["dao", "globals", "core/league", "core/player", "core/team", "lib/bluebi
             // Test if any warnings need to be displayed
             overCap = [false, false];
             ratios = [0, 0];
-
             return Promise.map([0, 1], function (j) {
                 var k;
                 if (j === 0) {
@@ -316,7 +315,7 @@ define(["dao", "globals", "core/league", "core/player", "core/team", "lib/bluebi
                         k = 0;
                     }
 
-                    s.warning = "The " + s.teams[j].name + " are over the salary cap, so the players it receives must have a combined salary of less than 125% of the salaries of the players it trades away. Currently, that value is " + ratios[j] + "%.  ";
+                    s.warning = "The " + s.teams[j].name + " are over the salary cap, so the players it receives must have a combined salary of less than 125% of the salaries of the players it trades away. Currently, that value is " + ratios[j] + "%.";
                     s.warning += "Bring the contribution of the " + s.teams[j].name + " up to $" + helpers.round(s.teams[k].total * 0.8, 2) + "M, lower the contribution of the " + s.teams[k].name + " to $" + helpers.round(s.teams[j].total * 1.25, 2) + "M, or otherwise rebalance the salaries involved.";
                 }
 

--- a/js/core/trade.js
+++ b/js/core/trade.js
@@ -319,7 +319,7 @@ define(["dao", "globals", "core/league", "core/player", "core/team", "lib/bluebi
                         j = 1;
                         k = 0;
                     }
-                    s.warning = "The " + s.teams[j].name + " are over the salary cap, so the players it receives must have a combined salary of less than 125% of the salaries of the players it trades away. Currently, that value is " + ratios[j] + "%.<br>";
+                    s.warning = "The " + s.teams[j].name + " are over the salary cap, so the players it receives must have a combined salary of less than 125% of the salaries of the players it trades away. Currently, that value is " + ratios[j] + "%.  ";
                     s.warning += "Bring the contribution of the " + s.teams[j].name + " up to $" + raiseLowSideTo[j] + "M, lower the contribution of the " + s.teams[k].name + " to $" + lowerHighSideTo[j] + "M, or otherwise rebalance the salaries involved.";
                 }
 

--- a/js/core/trade.js
+++ b/js/core/trade.js
@@ -273,13 +273,11 @@ define(["dao", "globals", "core/league", "core/player", "core/team", "lib/bluebi
         });
 
         return Promise.all(promises).then(function () {
-            var lowerHighSideTo, overCap, raiseLowSideTo, ratios;
+            var overCap, ratios;
 
             // Test if any warnings need to be displayed
             overCap = [false, false];
             ratios = [0, 0];
-            lowerHighSideTo = [0, 0];
-            raiseLowSideTo = [0, 0];
 
             return Promise.map([0, 1], function (j) {
                 var k;
@@ -293,8 +291,8 @@ define(["dao", "globals", "core/league", "core/player", "core/team", "lib/bluebi
 
                 if (s.teams[j].total > 0) {
                     ratios[j] = Math.floor((100 * s.teams[k].total) / s.teams[j].total);
-                    lowerHighSideTo[j] = helpers.round(s.teams[j].total * 1.25, 2);
-                    raiseLowSideTo[j] = helpers.round(s.teams[k].total * 0.8, 2);
+              //      lowerHighSideTo[j] = helpers.round(s.teams[j].total * 1.25, 2);
+               //     raiseLowSideTo[j] = helpers.round(s.teams[k].total * 0.8, 2);
                 } else if (s.teams[k].total > 0) {
                     ratios[j] = Infinity;
                 } else {
@@ -319,8 +317,9 @@ define(["dao", "globals", "core/league", "core/player", "core/team", "lib/bluebi
                         j = 1;
                         k = 0;
                     }
+
                     s.warning = "The " + s.teams[j].name + " are over the salary cap, so the players it receives must have a combined salary of less than 125% of the salaries of the players it trades away. Currently, that value is " + ratios[j] + "%.  ";
-                    s.warning += "Bring the contribution of the " + s.teams[j].name + " up to $" + raiseLowSideTo[j] + "M, lower the contribution of the " + s.teams[k].name + " to $" + lowerHighSideTo[j] + "M, or otherwise rebalance the salaries involved.";
+                    s.warning += "Bring the contribution of the " + s.teams[j].name + " up to $" + helpers.round(s.teams[k].total * 0.8, 2) + "M, lower the contribution of the " + s.teams[k].name + " to $" + helpers.round(s.teams[j].total * 1.25, 2) + "M, or otherwise rebalance the salaries involved.";
                 }
 
                 return s;

--- a/js/core/trade.js
+++ b/js/core/trade.js
@@ -314,7 +314,6 @@ define(["dao", "globals", "core/league", "core/player", "core/team", "lib/bluebi
                         j = 1;
                         k = 0;
                     }
-
                     s.warning = "The " + s.teams[j].name + " are over the salary cap, so the players it receives must have a combined salary of less than 125% of the salaries of the players it trades away.  Currently, that value is " + ratios[j] + "%.";
                     s.warning += "Bring the contribution of the " + s.teams[j].name + " up to $" + helpers.round(s.teams[k].total * 0.8, 2) + "M, lower the contribution of the " + s.teams[k].name + " to $" + helpers.round(s.teams[j].total * 1.25, 2) + "M, or otherwise rebalance the salaries involved.";
                 }

--- a/js/core/trade.js
+++ b/js/core/trade.js
@@ -313,9 +313,9 @@ define(["dao", "globals", "core/league", "core/player", "core/team", "lib/bluebi
                     } else {
                         j = 1;
                         k = 0;
-                    }
+                    }//formatCurrency(amount, append, precision)
                     s.warning = "The " + s.teams[j].name + " are over the salary cap, so the players it receives must have a combined salary of less than 125% of the salaries of the players it trades away.  Currently, that value is " + ratios[j] + "%.";
-                    s.warning += "Bring the contribution of the " + s.teams[j].name + " up to $" + helpers.round(s.teams[k].total * 0.8, 2) + "M, lower the contribution of the " + s.teams[k].name + " to $" + helpers.round(s.teams[j].total * 1.25, 2) + "M, or otherwise rebalance the salaries involved.";
+                    s.warning += "Bring the contribution of the " + s.teams[j].name + " up to " + helpers.formatCurrency(s.teams[k].total * 0.8, 'M', 2) + ", lower the contribution of the " + s.teams[k].name + " to " + helpers.formatCurrency(s.teams[j].total * 1.25, 'M', 2) + ", or otherwise rebalance the salaries involved.";
                 }
 
                 return s;

--- a/js/core/trade.js
+++ b/js/core/trade.js
@@ -291,8 +291,6 @@ define(["dao", "globals", "core/league", "core/player", "core/team", "lib/bluebi
 
                 if (s.teams[j].total > 0) {
                     ratios[j] = Math.floor((100 * s.teams[k].total) / s.teams[j].total);
-              //      lowerHighSideTo[j] = helpers.round(s.teams[j].total * 1.25, 2);
-               //     raiseLowSideTo[j] = helpers.round(s.teams[k].total * 0.8, 2);
                 } else if (s.teams[k].total > 0) {
                     ratios[j] = Infinity;
                 } else {

--- a/js/core/trade.js
+++ b/js/core/trade.js
@@ -303,19 +303,17 @@ define(["dao", "globals", "core/league", "core/player", "core/team", "lib/bluebi
                     }
                 });
             }).then(function () {
-                var j, k;
+                var j;
 
                 if ((ratios[0] > 125 && overCap[0] === true) || (ratios[1] > 125 && overCap[1] === true)) {
                     // Which team is at fault?;
                     if (ratios[0] > 125) {
                         j = 0;
-                        k = 1;
                     } else {
                         j = 1;
-                        k = 0;
-                    }//formatCurrency(amount, append, precision)
+                    }
                     s.warning = "The " + s.teams[j].name + " are over the salary cap, so the players it receives must have a combined salary of less than 125% of the salaries of the players it trades away.  Currently, that value is " + ratios[j] + "%.";
-                    s.warning += "Bring the contribution of the " + s.teams[j].name + " up to " + helpers.formatCurrency(s.teams[k].total * 0.8, 'M', 2) + ", lower the contribution of the " + s.teams[k].name + " to " + helpers.formatCurrency(s.teams[j].total * 1.25, 'M', 2) + ", or otherwise rebalance the salaries involved.";
+                    s.warning += "Bring the contribution of the " + s.teams[j].name + " up to " + helpers.formatCurrency(s.teams[1-j].total * 0.8, 'M', 2) + ", lower the contribution of the " + s.teams[1-j].name + " to " + helpers.formatCurrency(s.teams[j].total * 1.25, 'M', 2) + ", or otherwise rebalance the salaries involved.";
                 }
 
                 return s;

--- a/js/core/trade.js
+++ b/js/core/trade.js
@@ -315,7 +315,7 @@ define(["dao", "globals", "core/league", "core/player", "core/team", "lib/bluebi
                         k = 0;
                     }
 
-                    s.warning = "The " + s.teams[j].name + " are over the salary cap, so the players it receives must have a combined salary of less than 125% of the salaries of the players it trades away. Currently, that value is " + ratios[j] + "%.";
+                    s.warning = "The " + s.teams[j].name + " are over the salary cap, so the players it receives must have a combined salary of less than 125% of the salaries of the players it trades away.  Currently, that value is " + ratios[j] + "%.";
                     s.warning += "Bring the contribution of the " + s.teams[j].name + " up to $" + helpers.round(s.teams[k].total * 0.8, 2) + "M, lower the contribution of the " + s.teams[k].name + " to $" + helpers.round(s.teams[j].total * 1.25, 2) + "M, or otherwise rebalance the salaries involved.";
                 }
 


### PR DESCRIPTION
Hi Jeremy,
I doubt you will want this but its here if you do.  I'm going to be using it in my local version though so even if you don't want it for the main branch, any feedback would be appreciated.

Basically it just adds to the "warning" message on the trade page when the salaries don't work.  It adds the amounts that you'd need to raise or lower either sides contributions to in order to make a deal legal, e.g. 
"Bring the contribution of the Vancouver Whalers up to $15.84M, lower the contribution of the Denver High to $18.63M, or otherwise rebalance the salaries involved."

Thanks!