### PR TITLE
Playoffs and Standings tiebreakers

### DIFF
--- a/data/sample_tiebreakers.json
+++ b/data/sample_tiebreakers.json
@@ -1,0 +1,5242 @@
+{
+  "meta": {
+    "phaseText": "2015 playoffs",
+    "name": "League 12"
+  },
+  "teams": [
+    {
+      "tid": 0,
+      "cid": 0,
+      "did": 2,
+      "region": "Atlanta",
+      "name": "Gold Club",
+      "abbrev": "ATL",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19729.999999999985,
+          "fg": 3313,
+          "fga": 7328,
+          "fgAtRim": 723,
+          "fgaAtRim": 1150,
+          "fgLowPost": 994,
+          "fgaLowPost": 1904,
+          "fgMidRange": 804,
+          "fgaMidRange": 2246,
+          "tp": 792,
+          "tpa": 2028,
+          "ft": 1544,
+          "fta": 1899,
+          "orb": 826,
+          "drb": 2689,
+          "trb": 3515,
+          "ast": 2235,
+          "tov": 1017,
+          "stl": 718,
+          "blk": 310,
+          "ba": 369,
+          "pf": 1210,
+          "pts": 8962,
+          "oppPts": 8393
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 622645,
+          "cash": 24488.366643675654,
+          "won": 52,
+          "lost": 30,
+          "wonHome": 28,
+          "lostHome": 13,
+          "wonAway": 24,
+          "lostAway": 17,
+          "wonDiv": 6,
+          "lostDiv": 10,
+          "wonConf": 33,
+          "lostConf": 19,
+          "lastTen": [
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            1
+          ],
+          "streak": 7,
+          "playoffRoundsWon": 0,
+          "hype": 0.48702051998206575,
+          "pop": 4.3,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 5225.473393522918,
+              "rank": 22
+            },
+            "sponsor": {
+              "amount": 17418.24464507639,
+              "rank": 22
+            },
+            "ticket": {
+              "amount": 60776.40396,
+              "rank": 20
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 17418.24464507639,
+              "rank": 22
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 47250.000000000044,
+              "rank": 20
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 14900.000000000013,
+              "rank": 11
+            },
+            "coaching": {
+              "amount": 14900.000000000013,
+              "rank": 11
+            },
+            "health": {
+              "amount": 14900.000000000013,
+              "rank": 11
+            },
+            "facilities": {
+              "amount": 14900.000000000013,
+              "rank": 11
+            }
+          },
+          "payrollEndOfSeason": 47250
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "41.38",
+          "rank": 11
+        },
+        "scouting": {
+          "amount": 14900,
+          "rank": 11
+        },
+        "coaching": {
+          "amount": 14900,
+          "rank": 11
+        },
+        "health": {
+          "amount": 14900,
+          "rank": 11
+        },
+        "facilities": {
+          "amount": 14900,
+          "rank": 11
+        }
+      },
+      "strategy": "contending"
+    },
+    {
+      "tid": 1,
+      "cid": 0,
+      "did": 2,
+      "region": "Baltimore",
+      "name": "Crabs",
+      "abbrev": "BAL",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19705.000000000073,
+          "fg": 2886,
+          "fga": 6794,
+          "fgAtRim": 960,
+          "fgaAtRim": 1656,
+          "fgLowPost": 1005,
+          "fgaLowPost": 2195,
+          "fgMidRange": 647,
+          "fgaMidRange": 2086,
+          "tp": 274,
+          "tpa": 857,
+          "ft": 1848,
+          "fta": 2425,
+          "orb": 962,
+          "drb": 2776,
+          "trb": 3738,
+          "ast": 1688,
+          "tov": 1331,
+          "stl": 522,
+          "blk": 375,
+          "ba": 319,
+          "pf": 1135,
+          "pts": 7894,
+          "oppPts": 8355
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 1017849,
+          "cash": 58186.41387846379,
+          "won": 30,
+          "lost": 52,
+          "wonHome": 16,
+          "lostHome": 25,
+          "wonAway": 14,
+          "lostAway": 27,
+          "wonDiv": 0,
+          "lostDiv": 16,
+          "wonConf": 14,
+          "lostConf": 38,
+          "lastTen": [
+            1,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            0
+          ],
+          "streak": 3,
+          "playoffRoundsWon": -1,
+          "hype": 0.7269791788946056,
+          "pop": 2.2,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 6168.8410854305885,
+              "rank": 14
+            },
+            "sponsor": {
+              "amount": 20562.803618101963,
+              "rank": 14
+            },
+            "ticket": {
+              "amount": 66269.28263,
+              "rank": 15
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 20562.803618101963,
+              "rank": 14
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 27257.317073170743,
+              "rank": 30
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 12700,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 11480,
+              "rank": 22
+            },
+            "coaching": {
+              "amount": 11480,
+              "rank": 22
+            },
+            "health": {
+              "amount": 11480,
+              "rank": 22
+            },
+            "facilities": {
+              "amount": 11480,
+              "rank": 22
+            }
+          },
+          "payrollEndOfSeason": 27300
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "31.90",
+          "rank": 22
+        },
+        "scouting": {
+          "amount": 11480,
+          "rank": 22
+        },
+        "coaching": {
+          "amount": 11480,
+          "rank": 22
+        },
+        "health": {
+          "amount": 11480,
+          "rank": 22
+        },
+        "facilities": {
+          "amount": 11480,
+          "rank": 22
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 2,
+      "cid": 0,
+      "did": 0,
+      "region": "Boston",
+      "name": "Massacre",
+      "abbrev": "BOS",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19780.00000000005,
+          "fg": 3189,
+          "fga": 7057,
+          "fgAtRim": 1214,
+          "fgaAtRim": 1978,
+          "fgLowPost": 863,
+          "fgaLowPost": 1822,
+          "fgMidRange": 643,
+          "fgaMidRange": 1895,
+          "tp": 469,
+          "tpa": 1362,
+          "ft": 1607,
+          "fta": 2133,
+          "orb": 924,
+          "drb": 2860,
+          "trb": 3784,
+          "ast": 1945,
+          "tov": 1172,
+          "stl": 667,
+          "blk": 410,
+          "ba": 361,
+          "pf": 1190,
+          "pts": 8454,
+          "oppPts": 7875
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 1025000,
+          "cash": 72311.7967493849,
+          "won": 49,
+          "lost": 33,
+          "wonHome": 26,
+          "lostHome": 15,
+          "wonAway": 23,
+          "lostAway": 18,
+          "wonDiv": 10,
+          "lostDiv": 6,
+          "wonConf": 31,
+          "lostConf": 21,
+          "lastTen": [
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            1,
+            0
+          ],
+          "streak": 2,
+          "playoffRoundsWon": 0,
+          "hype": 1,
+          "pop": 4.4,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 8962.543828615424,
+              "rank": 4
+            },
+            "sponsor": {
+              "amount": 29875.146095384745,
+              "rank": 3
+            },
+            "ticket": {
+              "amount": 77778.96073,
+              "rank": 5
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 29875.146095384745,
+              "rank": 4
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 42599.99999999996,
+              "rank": 21
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 15520.000000000022,
+              "rank": 9
+            },
+            "coaching": {
+              "amount": 15520.000000000022,
+              "rank": 9
+            },
+            "health": {
+              "amount": 15520.000000000022,
+              "rank": 9
+            },
+            "facilities": {
+              "amount": 15520.000000000022,
+              "rank": 9
+            }
+          },
+          "payrollEndOfSeason": 42600
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "43.10",
+          "rank": 9
+        },
+        "scouting": {
+          "amount": 15520,
+          "rank": 9
+        },
+        "coaching": {
+          "amount": 15520,
+          "rank": 9
+        },
+        "health": {
+          "amount": 15520,
+          "rank": 9
+        },
+        "facilities": {
+          "amount": 15520,
+          "rank": 9
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 3,
+      "cid": 0,
+      "did": 1,
+      "region": "Chicago",
+      "name": "Whirlwinds",
+      "abbrev": "CHI",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19730.00000000011,
+          "fg": 2984,
+          "fga": 6931,
+          "fgAtRim": 856,
+          "fgaAtRim": 1448,
+          "fgLowPost": 1124,
+          "fgaLowPost": 2319,
+          "fgMidRange": 706,
+          "fgaMidRange": 2212,
+          "tp": 298,
+          "tpa": 952,
+          "ft": 1705,
+          "fta": 2327,
+          "orb": 1079,
+          "drb": 2755,
+          "trb": 3834,
+          "ast": 1714,
+          "tov": 1280,
+          "stl": 539,
+          "blk": 393,
+          "ba": 384,
+          "pf": 1154,
+          "pts": 7971,
+          "oppPts": 8175
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 891596,
+          "cash": 52867.16244261731,
+          "won": 35,
+          "lost": 47,
+          "wonHome": 20,
+          "lostHome": 21,
+          "wonAway": 15,
+          "lostAway": 26,
+          "wonDiv": 7,
+          "lostDiv": 9,
+          "wonConf": 18,
+          "lostConf": 34,
+          "lastTen": [
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0
+          ],
+          "streak": -1,
+          "playoffRoundsWon": -1,
+          "hype": 0.24318610860259632,
+          "pop": 8.8,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 7125.697348655277,
+              "rank": 10
+            },
+            "sponsor": {
+              "amount": 23752.324495517598,
+              "rank": 10
+            },
+            "ticket": {
+              "amount": 75998.52341999998,
+              "rank": 6
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 23752.324495517598,
+              "rank": 10
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 32631.707317073142,
+              "rank": 26
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 7350,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 17070.000000000022,
+              "rank": 4
+            },
+            "coaching": {
+              "amount": 17070.000000000022,
+              "rank": 4
+            },
+            "health": {
+              "amount": 17070.000000000022,
+              "rank": 4
+            },
+            "facilities": {
+              "amount": 17070.000000000022,
+              "rank": 4
+            }
+          },
+          "payrollEndOfSeason": 32650
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "47.41",
+          "rank": 4
+        },
+        "scouting": {
+          "amount": 17070,
+          "rank": 4
+        },
+        "coaching": {
+          "amount": 17070,
+          "rank": 4
+        },
+        "health": {
+          "amount": 17070,
+          "rank": 4
+        },
+        "facilities": {
+          "amount": 17070,
+          "rank": 4
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 4,
+      "cid": 0,
+      "did": 1,
+      "region": "Cincinnati",
+      "name": "Riots",
+      "abbrev": "CIN",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19730.00000000005,
+          "fg": 3168,
+          "fga": 7098,
+          "fgAtRim": 905,
+          "fgaAtRim": 1427,
+          "fgLowPost": 969,
+          "fgaLowPost": 1927,
+          "fgMidRange": 778,
+          "fgaMidRange": 2182,
+          "tp": 516,
+          "tpa": 1562,
+          "ft": 1596,
+          "fta": 2050,
+          "orb": 973,
+          "drb": 2762,
+          "trb": 3735,
+          "ast": 1929,
+          "tov": 1182,
+          "stl": 608,
+          "blk": 401,
+          "ba": 337,
+          "pf": 1217,
+          "pts": 8448,
+          "oppPts": 8142
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 1025000,
+          "cash": 37191.46567197439,
+          "won": 50,
+          "lost": 32,
+          "wonHome": 26,
+          "lostHome": 15,
+          "wonAway": 24,
+          "lostAway": 17,
+          "wonDiv": 11,
+          "lostDiv": 5,
+          "wonConf": 27,
+          "lostConf": 25,
+          "lastTen": [
+            1,
+            0,
+            1,
+            1,
+            0,
+            1,
+            0,
+            0,
+            1,
+            1
+          ],
+          "streak": 1,
+          "playoffRoundsWon": 0,
+          "hype": 1,
+          "pop": 1.6,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 5744.3660363444815,
+              "rank": 17
+            },
+            "sponsor": {
+              "amount": 19147.886787814947,
+              "rank": 17
+            },
+            "ticket": {
+              "amount": 60191.326059999985,
+              "rank": 22
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 19147.886787814947,
+              "rank": 17
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 60299.999999999935,
+              "rank": 10
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 9310.00000000001,
+              "rank": 29
+            },
+            "coaching": {
+              "amount": 9310.00000000001,
+              "rank": 29
+            },
+            "health": {
+              "amount": 9310.00000000001,
+              "rank": 29
+            },
+            "facilities": {
+              "amount": 9310.00000000001,
+              "rank": 29
+            }
+          },
+          "payrollEndOfSeason": 60300
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "25.86",
+          "rank": 29
+        },
+        "scouting": {
+          "amount": 9310,
+          "rank": 29
+        },
+        "coaching": {
+          "amount": 9310,
+          "rank": 29
+        },
+        "health": {
+          "amount": 9310,
+          "rank": 29
+        },
+        "facilities": {
+          "amount": 9310,
+          "rank": 29
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 5,
+      "cid": 0,
+      "did": 1,
+      "region": "Cleveland",
+      "name": "Curses",
+      "abbrev": "CLE",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19755.00000000007,
+          "fg": 3170,
+          "fga": 7113,
+          "fgAtRim": 960,
+          "fgaAtRim": 1531,
+          "fgLowPost": 957,
+          "fgaLowPost": 1936,
+          "fgMidRange": 728,
+          "fgaMidRange": 2195,
+          "tp": 525,
+          "tpa": 1451,
+          "ft": 1749,
+          "fta": 2233,
+          "orb": 934,
+          "drb": 2799,
+          "trb": 3733,
+          "ast": 2018,
+          "tov": 1105,
+          "stl": 699,
+          "blk": 389,
+          "ba": 345,
+          "pf": 1199,
+          "pts": 8614,
+          "oppPts": 8088
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 921028,
+          "cash": 22352.593342323053,
+          "won": 51,
+          "lost": 31,
+          "wonHome": 29,
+          "lostHome": 12,
+          "wonAway": 22,
+          "lostAway": 19,
+          "wonDiv": 11,
+          "lostDiv": 5,
+          "wonConf": 32,
+          "lostConf": 20,
+          "lastTen": [
+            1,
+            0,
+            1,
+            0,
+            1,
+            1,
+            1,
+            0,
+            0,
+            1
+          ],
+          "streak": 1,
+          "playoffRoundsWon": 0,
+          "hype": 0.8849846760804015,
+          "pop": 1.9,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 5289.253243346485,
+              "rank": 21
+            },
+            "sponsor": {
+              "amount": 17630.844144488285,
+              "rank": 21
+            },
+            "ticket": {
+              "amount": 60376.65181000001,
+              "rank": 21
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 17630.844144488285,
+              "rank": 21
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 65750.00000000006,
+              "rank": 3
+            },
+            "luxuryTax": {
+              "amount": 1125,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 10550.000000000013,
+              "rank": 25
+            },
+            "coaching": {
+              "amount": 10550.000000000013,
+              "rank": 25
+            },
+            "health": {
+              "amount": 10550.000000000013,
+              "rank": 25
+            },
+            "facilities": {
+              "amount": 10550.000000000013,
+              "rank": 25
+            }
+          },
+          "payrollEndOfSeason": 65750
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "29.31",
+          "rank": 25
+        },
+        "scouting": {
+          "amount": 10550,
+          "rank": 25
+        },
+        "coaching": {
+          "amount": 10550,
+          "rank": 25
+        },
+        "health": {
+          "amount": 10550,
+          "rank": 25
+        },
+        "facilities": {
+          "amount": 10550,
+          "rank": 25
+        }
+      },
+      "strategy": "contending"
+    },
+    {
+      "tid": 6,
+      "cid": 1,
+      "did": 3,
+      "region": "Dallas",
+      "name": "Snipers",
+      "abbrev": "DAL",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19705.000000000055,
+          "fg": 3081,
+          "fga": 7006,
+          "fgAtRim": 1006,
+          "fgaAtRim": 1637,
+          "fgLowPost": 877,
+          "fgaLowPost": 1792,
+          "fgMidRange": 819,
+          "fgaMidRange": 2338,
+          "tp": 379,
+          "tpa": 1239,
+          "ft": 1686,
+          "fta": 2145,
+          "orb": 801,
+          "drb": 2616,
+          "trb": 3417,
+          "ast": 1968,
+          "tov": 1116,
+          "stl": 585,
+          "blk": 340,
+          "ba": 326,
+          "pf": 1201,
+          "pts": 8227,
+          "oppPts": 8589
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 1004576,
+          "cash": 55757.40551887043,
+          "won": 30,
+          "lost": 52,
+          "wonHome": 14,
+          "lostHome": 27,
+          "wonAway": 16,
+          "lostAway": 25,
+          "wonDiv": 9,
+          "lostDiv": 7,
+          "wonConf": 24,
+          "lostConf": 28,
+          "lastTen": [
+            1,
+            0,
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            1,
+            1
+          ],
+          "streak": 1,
+          "playoffRoundsWon": -1,
+          "hype": 0.5489105612419118,
+          "pop": 4.7,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 7177.059719725409,
+              "rank": 9
+            },
+            "sponsor": {
+              "amount": 23923.53239908471,
+              "rank": 9
+            },
+            "ticket": {
+              "amount": 75297.18344000001,
+              "rank": 7
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 23923.53239908471,
+              "rank": 9
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 41743.90243902441,
+              "rank": 22
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 15829.999999999998,
+              "rank": 8
+            },
+            "coaching": {
+              "amount": 15829.999999999998,
+              "rank": 8
+            },
+            "health": {
+              "amount": 15829.999999999998,
+              "rank": 8
+            },
+            "facilities": {
+              "amount": 15829.999999999998,
+              "rank": 8
+            }
+          },
+          "payrollEndOfSeason": 41750
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "43.97",
+          "rank": 8
+        },
+        "scouting": {
+          "amount": 15830,
+          "rank": 8
+        },
+        "coaching": {
+          "amount": 15830,
+          "rank": 8
+        },
+        "health": {
+          "amount": 15830,
+          "rank": 8
+        },
+        "facilities": {
+          "amount": 15830,
+          "rank": 8
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 7,
+      "cid": 1,
+      "did": 4,
+      "region": "Denver",
+      "name": "High",
+      "abbrev": "DEN",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19705.000000000055,
+          "fg": 3212,
+          "fga": 7111,
+          "fgAtRim": 956,
+          "fgaAtRim": 1565,
+          "fgLowPost": 917,
+          "fgaLowPost": 1801,
+          "fgMidRange": 816,
+          "fgaMidRange": 2261,
+          "tp": 523,
+          "tpa": 1484,
+          "ft": 1675,
+          "fta": 2155,
+          "orb": 872,
+          "drb": 2853,
+          "trb": 3725,
+          "ast": 1994,
+          "tov": 1102,
+          "stl": 788,
+          "blk": 348,
+          "ba": 396,
+          "pf": 1245,
+          "pts": 8622,
+          "oppPts": 7658
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 583357,
+          "cash": -9202.21080538443,
+          "won": 58,
+          "lost": 24,
+          "wonHome": 31,
+          "lostHome": 10,
+          "wonAway": 27,
+          "lostAway": 14,
+          "wonDiv": 14,
+          "lostDiv": 2,
+          "wonConf": 41,
+          "lostConf": 11,
+          "lastTen": [
+            0,
+            1,
+            1,
+            1,
+            0,
+            1,
+            0,
+            1,
+            1,
+            0
+          ],
+          "streak": -1,
+          "playoffRoundsWon": 0,
+          "hype": 0.6325758450687502,
+          "pop": 2.2,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 4377.671768428117,
+              "rank": 26
+            },
+            "sponsor": {
+              "amount": 14592.239228093718,
+              "rank": 26
+            },
+            "ticket": {
+              "amount": 50895.638969999985,
+              "rank": 26
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 14592.239228093718,
+              "rank": 26
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 69800.00000000004,
+              "rank": 2
+            },
+            "luxuryTax": {
+              "amount": 7200,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 11789.999999999989,
+              "rank": 21
+            },
+            "coaching": {
+              "amount": 11789.999999999989,
+              "rank": 21
+            },
+            "health": {
+              "amount": 11789.999999999989,
+              "rank": 21
+            },
+            "facilities": {
+              "amount": 11789.999999999989,
+              "rank": 21
+            }
+          },
+          "payrollEndOfSeason": 69800
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "32.76",
+          "rank": 21
+        },
+        "scouting": {
+          "amount": 11790,
+          "rank": 21
+        },
+        "coaching": {
+          "amount": 11790,
+          "rank": 21
+        },
+        "health": {
+          "amount": 11790,
+          "rank": 21
+        },
+        "facilities": {
+          "amount": 11790,
+          "rank": 21
+        }
+      },
+      "strategy": "contending"
+    },
+    {
+      "tid": 8,
+      "cid": 0,
+      "did": 1,
+      "region": "Detroit",
+      "name": "Muscle",
+      "abbrev": "DET",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19730.000000000047,
+          "fg": 2994,
+          "fga": 6926,
+          "fgAtRim": 918,
+          "fgaAtRim": 1517,
+          "fgLowPost": 852,
+          "fgaLowPost": 1806,
+          "fgMidRange": 743,
+          "fgaMidRange": 2211,
+          "tp": 481,
+          "tpa": 1392,
+          "ft": 1729,
+          "fta": 2146,
+          "orb": 901,
+          "drb": 2580,
+          "trb": 3481,
+          "ast": 1866,
+          "tov": 1192,
+          "stl": 554,
+          "blk": 305,
+          "ba": 370,
+          "pf": 1214,
+          "pts": 8198,
+          "oppPts": 8738
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 1025000,
+          "cash": 65585.63214829154,
+          "won": 30,
+          "lost": 52,
+          "wonHome": 15,
+          "lostHome": 26,
+          "wonAway": 15,
+          "lostAway": 26,
+          "wonDiv": 4,
+          "lostDiv": 12,
+          "wonConf": 18,
+          "lostConf": 34,
+          "lastTen": [
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0
+          ],
+          "streak": -1,
+          "playoffRoundsWon": -1,
+          "hype": 0.703427262578494,
+          "pop": 4,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 7541.583695662629,
+              "rank": 7
+            },
+            "sponsor": {
+              "amount": 25138.612318875435,
+              "rank": 7
+            },
+            "ticket": {
+              "amount": 73116.33601,
+              "rank": 10
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 25138.612318875435,
+              "rank": 7
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 39319.51219512195,
+              "rank": 23
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 650,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 13970.000000000013,
+              "rank": 14
+            },
+            "coaching": {
+              "amount": 13970.000000000013,
+              "rank": 14
+            },
+            "health": {
+              "amount": 13970.000000000013,
+              "rank": 14
+            },
+            "facilities": {
+              "amount": 13970.000000000013,
+              "rank": 14
+            }
+          },
+          "payrollEndOfSeason": 39350
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "38.79",
+          "rank": 14
+        },
+        "scouting": {
+          "amount": 13970,
+          "rank": 14
+        },
+        "coaching": {
+          "amount": 13970,
+          "rank": 14
+        },
+        "health": {
+          "amount": 13970,
+          "rank": 14
+        },
+        "facilities": {
+          "amount": 13970,
+          "rank": 14
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 9,
+      "cid": 1,
+      "did": 3,
+      "region": "Houston",
+      "name": "Apollos",
+      "abbrev": "HOU",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19680.000000000022,
+          "fg": 3125,
+          "fga": 7172,
+          "fgAtRim": 821,
+          "fgaAtRim": 1320,
+          "fgLowPost": 727,
+          "fgaLowPost": 1514,
+          "fgMidRange": 1035,
+          "fgaMidRange": 2782,
+          "tp": 542,
+          "tpa": 1556,
+          "ft": 1445,
+          "fta": 1831,
+          "orb": 749,
+          "drb": 2542,
+          "trb": 3291,
+          "ast": 2050,
+          "tov": 1069,
+          "stl": 649,
+          "blk": 291,
+          "ba": 341,
+          "pf": 1237,
+          "pts": 8237,
+          "oppPts": 8851
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 797211,
+          "cash": 16720.27013134855,
+          "won": 34,
+          "lost": 48,
+          "wonHome": 22,
+          "lostHome": 19,
+          "wonAway": 12,
+          "lostAway": 29,
+          "wonDiv": 5,
+          "lostDiv": 11,
+          "wonConf": 22,
+          "lostConf": 30,
+          "lastTen": [
+            0,
+            0,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0
+          ],
+          "streak": -3,
+          "playoffRoundsWon": -1,
+          "hype": 0.39461461572504736,
+          "pop": 4.3,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 5692.277387132416,
+              "rank": 18
+            },
+            "sponsor": {
+              "amount": 18974.257957108053,
+              "rank": 18
+            },
+            "ticket": {
+              "amount": 64519.47683000001,
+              "rank": 16
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 18974.257957108053,
+              "rank": 18
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 61099.99999999991,
+              "rank": 8
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 15209.999999999975,
+              "rank": 10
+            },
+            "coaching": {
+              "amount": 15209.999999999975,
+              "rank": 10
+            },
+            "health": {
+              "amount": 15209.999999999975,
+              "rank": 10
+            },
+            "facilities": {
+              "amount": 15209.999999999975,
+              "rank": 10
+            }
+          },
+          "payrollEndOfSeason": 61100
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "42.24",
+          "rank": 10
+        },
+        "scouting": {
+          "amount": 15210,
+          "rank": 10
+        },
+        "coaching": {
+          "amount": 15210,
+          "rank": 10
+        },
+        "health": {
+          "amount": 15210,
+          "rank": 10
+        },
+        "facilities": {
+          "amount": 15210,
+          "rank": 10
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 10,
+      "cid": 1,
+      "did": 5,
+      "region": "Las Vegas",
+      "name": "Blue Chips",
+      "abbrev": "LV",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19730.000000000025,
+          "fg": 2977,
+          "fga": 6894,
+          "fgAtRim": 796,
+          "fgaAtRim": 1384,
+          "fgLowPost": 914,
+          "fgaLowPost": 1904,
+          "fgMidRange": 685,
+          "fgaMidRange": 2011,
+          "tp": 582,
+          "tpa": 1595,
+          "ft": 1600,
+          "fta": 2098,
+          "orb": 966,
+          "drb": 2731,
+          "trb": 3697,
+          "ast": 1775,
+          "tov": 1255,
+          "stl": 553,
+          "blk": 380,
+          "ba": 382,
+          "pf": 1200,
+          "pts": 8136,
+          "oppPts": 8268
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 589223,
+          "cash": 22159.259126611483,
+          "won": 37,
+          "lost": 45,
+          "wonHome": 20,
+          "lostHome": 21,
+          "wonAway": 17,
+          "lostAway": 24,
+          "wonDiv": 7,
+          "lostDiv": 9,
+          "wonConf": 25,
+          "lostConf": 27,
+          "lastTen": [
+            1,
+            1,
+            0,
+            0,
+            0,
+            1,
+            0,
+            1,
+            1,
+            1
+          ],
+          "streak": 2,
+          "playoffRoundsWon": 0,
+          "hype": 0.288022879964602,
+          "pop": 1.7,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 4108.155466164591,
+              "rank": 29
+            },
+            "sponsor": {
+              "amount": 13693.851553881974,
+              "rank": 29
+            },
+            "ticket": {
+              "amount": 47564.13225999999,
+              "rank": 29
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 13693.851553881974,
+              "rank": 29
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 48920.731707317005,
+              "rank": 19
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 9620,
+              "rank": 28
+            },
+            "coaching": {
+              "amount": 9620,
+              "rank": 28
+            },
+            "health": {
+              "amount": 9620,
+              "rank": 28
+            },
+            "facilities": {
+              "amount": 9620,
+              "rank": 28
+            }
+          },
+          "payrollEndOfSeason": 49000
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "26.72",
+          "rank": 28
+        },
+        "scouting": {
+          "amount": 9620,
+          "rank": 28
+        },
+        "coaching": {
+          "amount": 9620,
+          "rank": 28
+        },
+        "health": {
+          "amount": 9620,
+          "rank": 28
+        },
+        "facilities": {
+          "amount": 9620,
+          "rank": 28
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 11,
+      "cid": 1,
+      "did": 5,
+      "region": "Los Angeles",
+      "name": "Earthquakes",
+      "abbrev": "LA",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19780.000000000087,
+          "fg": 3014,
+          "fga": 6876,
+          "fgAtRim": 1021,
+          "fgaAtRim": 1681,
+          "fgLowPost": 838,
+          "fgaLowPost": 1731,
+          "fgMidRange": 740,
+          "fgaMidRange": 2180,
+          "tp": 415,
+          "tpa": 1284,
+          "ft": 1713,
+          "fta": 2223,
+          "orb": 783,
+          "drb": 2545,
+          "trb": 3328,
+          "ast": 1855,
+          "tov": 1156,
+          "stl": 561,
+          "blk": 352,
+          "ba": 341,
+          "pf": 1278,
+          "pts": 8156,
+          "oppPts": 8811
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 982103,
+          "cash": 66831.47841162534,
+          "won": 24,
+          "lost": 58,
+          "wonHome": 15,
+          "lostHome": 26,
+          "wonAway": 9,
+          "lostAway": 32,
+          "wonDiv": 4,
+          "lostDiv": 12,
+          "wonConf": 16,
+          "lostConf": 36,
+          "lastTen": [
+            0,
+            1,
+            0,
+            0,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0
+          ],
+          "streak": -1,
+          "playoffRoundsWon": -1,
+          "hype": 0.20169261593105975,
+          "pop": 12.3,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 8898.582239670075,
+              "rank": 5
+            },
+            "sponsor": {
+              "amount": 28179.045222446657,
+              "rank": 5
+            },
+            "ticket": {
+              "amount": 79021.48061,
+              "rank": 4
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 29709.68741267938,
+              "rank": 5
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 30107.3170731707,
+              "rank": 28
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 9850,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 17379.999999999993,
+              "rank": 3
+            },
+            "coaching": {
+              "amount": 17379.999999999993,
+              "rank": 3
+            },
+            "health": {
+              "amount": 17379.999999999993,
+              "rank": 3
+            },
+            "facilities": {
+              "amount": 17379.999999999993,
+              "rank": 3
+            }
+          },
+          "payrollEndOfSeason": 30150
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "48.28",
+          "rank": 3
+        },
+        "scouting": {
+          "amount": 17380,
+          "rank": 3
+        },
+        "coaching": {
+          "amount": 17380,
+          "rank": 3
+        },
+        "health": {
+          "amount": 17380,
+          "rank": 3
+        },
+        "facilities": {
+          "amount": 17380,
+          "rank": 3
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 12,
+      "cid": 1,
+      "did": 3,
+      "region": "Mexico City",
+      "name": "Aztecs",
+      "abbrev": "MXC",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19680.00000000005,
+          "fg": 3473,
+          "fga": 7337,
+          "fgAtRim": 808,
+          "fgaAtRim": 1294,
+          "fgLowPost": 902,
+          "fgaLowPost": 1715,
+          "fgMidRange": 1056,
+          "fgaMidRange": 2543,
+          "tp": 707,
+          "tpa": 1785,
+          "ft": 1476,
+          "fta": 1887,
+          "orb": 827,
+          "drb": 2822,
+          "trb": 3649,
+          "ast": 2276,
+          "tov": 1052,
+          "stl": 639,
+          "blk": 367,
+          "ba": 328,
+          "pf": 1207,
+          "pts": 9129,
+          "oppPts": 8338
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 1025000,
+          "cash": 78504.95533554856,
+          "won": 56,
+          "lost": 26,
+          "wonHome": 28,
+          "lostHome": 13,
+          "wonAway": 28,
+          "lostAway": 13,
+          "wonDiv": 12,
+          "lostDiv": 4,
+          "wonConf": 37,
+          "lostConf": 15,
+          "lastTen": [
+            1,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            1
+          ],
+          "streak": 1,
+          "playoffRoundsWon": 0,
+          "hype": 0.9920937737907981,
+          "pop": 19.4,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 12683.062999999998,
+              "rank": 1
+            },
+            "sponsor": {
+              "amount": 32710.21,
+              "rank": 2
+            },
+            "ticket": {
+              "amount": 81246.94667000002,
+              "rank": 2
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 56164.735665548425,
+              "rank": 1
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 62800.000000000044,
+              "rank": 6
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 18000.000000000025,
+              "rank": 1
+            },
+            "coaching": {
+              "amount": 18000.000000000025,
+              "rank": 1
+            },
+            "health": {
+              "amount": 18000.000000000025,
+              "rank": 1
+            },
+            "facilities": {
+              "amount": 18000.000000000025,
+              "rank": 1
+            }
+          },
+          "payrollEndOfSeason": 62800
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "50.00",
+          "rank": 1
+        },
+        "scouting": {
+          "amount": 18000,
+          "rank": 1
+        },
+        "coaching": {
+          "amount": 18000,
+          "rank": 1
+        },
+        "health": {
+          "amount": 18000,
+          "rank": 1
+        },
+        "facilities": {
+          "amount": 18000,
+          "rank": 1
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 13,
+      "cid": 0,
+      "did": 2,
+      "region": "Miami",
+      "name": "Cyclones",
+      "abbrev": "MIA",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19680,
+          "fg": 3372,
+          "fga": 7223,
+          "fgAtRim": 1039,
+          "fgaAtRim": 1629,
+          "fgLowPost": 1125,
+          "fgaLowPost": 2176,
+          "fgMidRange": 719,
+          "fgaMidRange": 2073,
+          "tp": 489,
+          "tpa": 1345,
+          "ft": 1696,
+          "fta": 2177,
+          "orb": 997,
+          "drb": 3022,
+          "trb": 4019,
+          "ast": 2140,
+          "tov": 1108,
+          "stl": 774,
+          "blk": 454,
+          "ba": 369,
+          "pf": 1236,
+          "pts": 8929,
+          "oppPts": 7554
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 888237,
+          "cash": -45748.483684663326,
+          "won": 66,
+          "lost": 16,
+          "wonHome": 34,
+          "lostHome": 7,
+          "wonAway": 32,
+          "lostAway": 9,
+          "wonDiv": 12,
+          "lostDiv": 4,
+          "wonConf": 40,
+          "lostConf": 12,
+          "lastTen": [
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            1,
+            1,
+            1,
+            1
+          ],
+          "streak": 4,
+          "playoffRoundsWon": 0,
+          "hype": 0.9991396385868807,
+          "pop": 5.4,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 7182.2195811308675,
+              "rank": 8
+            },
+            "sponsor": {
+              "amount": 23940.731937102893,
+              "rank": 8
+            },
+            "ticket": {
+              "amount": 73997.83286000001,
+              "rank": 9
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 23940.731937102893,
+              "rank": 8
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 95300.00000000017,
+              "rank": 1
+            },
+            "luxuryTax": {
+              "amount": 45450,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 16139.999999999975,
+              "rank": 7
+            },
+            "coaching": {
+              "amount": 16139.999999999975,
+              "rank": 7
+            },
+            "health": {
+              "amount": 16139.999999999975,
+              "rank": 7
+            },
+            "facilities": {
+              "amount": 16139.999999999975,
+              "rank": 7
+            }
+          },
+          "payrollEndOfSeason": 95300
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "44.83",
+          "rank": 7
+        },
+        "scouting": {
+          "amount": 16140,
+          "rank": 7
+        },
+        "coaching": {
+          "amount": 16140,
+          "rank": 7
+        },
+        "health": {
+          "amount": 16140,
+          "rank": 7
+        },
+        "facilities": {
+          "amount": 16140,
+          "rank": 7
+        }
+      },
+      "strategy": "contending"
+    },
+    {
+      "tid": 14,
+      "cid": 1,
+      "did": 4,
+      "region": "Minneapolis",
+      "name": "Blizzards",
+      "abbrev": "MIN",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19705.000000000036,
+          "fg": 3333,
+          "fga": 7234,
+          "fgAtRim": 871,
+          "fgaAtRim": 1330,
+          "fgLowPost": 882,
+          "fgaLowPost": 1714,
+          "fgMidRange": 921,
+          "fgaMidRange": 2402,
+          "tp": 659,
+          "tpa": 1788,
+          "ft": 1487,
+          "fta": 1874,
+          "orb": 897,
+          "drb": 2746,
+          "trb": 3643,
+          "ast": 2136,
+          "tov": 1148,
+          "stl": 599,
+          "blk": 366,
+          "ba": 352,
+          "pf": 1240,
+          "pts": 8812,
+          "oppPts": 8338
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 565153,
+          "cash": 7813.205794088158,
+          "won": 45,
+          "lost": 37,
+          "wonHome": 25,
+          "lostHome": 16,
+          "wonAway": 20,
+          "lostAway": 21,
+          "wonDiv": 11,
+          "lostDiv": 5,
+          "wonConf": 30,
+          "lostConf": 22,
+          "lastTen": [
+            1,
+            0,
+            1,
+            1,
+            1,
+            0,
+            0,
+            0,
+            1,
+            1
+          ],
+          "streak": 1,
+          "playoffRoundsWon": 0,
+          "hype": 0.3872281088858311,
+          "pop": 2.6,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 4407.942360533238,
+              "rank": 25
+            },
+            "sponsor": {
+              "amount": 14693.141201777458,
+              "rank": 25
+            },
+            "ticket": {
+              "amount": 51258.98103000001,
+              "rank": 25
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 14693.141201777458,
+              "rank": 25
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 58099.99999999994,
+              "rank": 14
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 12409.999999999985,
+              "rank": 19
+            },
+            "coaching": {
+              "amount": 12409.999999999985,
+              "rank": 19
+            },
+            "health": {
+              "amount": 12409.999999999985,
+              "rank": 19
+            },
+            "facilities": {
+              "amount": 12409.999999999985,
+              "rank": 19
+            }
+          },
+          "payrollEndOfSeason": 58100
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "34.48",
+          "rank": 19
+        },
+        "scouting": {
+          "amount": 12410,
+          "rank": 19
+        },
+        "coaching": {
+          "amount": 12410,
+          "rank": 19
+        },
+        "health": {
+          "amount": 12410,
+          "rank": 19
+        },
+        "facilities": {
+          "amount": 12410,
+          "rank": 19
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 15,
+      "cid": 0,
+      "did": 0,
+      "region": "Montreal",
+      "name": "Mounties",
+      "abbrev": "MON",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19680.000000000062,
+          "fg": 3162,
+          "fga": 7239,
+          "fgAtRim": 1057,
+          "fgaAtRim": 1728,
+          "fgLowPost": 595,
+          "fgaLowPost": 1291,
+          "fgMidRange": 850,
+          "fgaMidRange": 2488,
+          "tp": 660,
+          "tpa": 1732,
+          "ft": 1490,
+          "fta": 1925,
+          "orb": 805,
+          "drb": 2633,
+          "trb": 3438,
+          "ast": 2041,
+          "tov": 1062,
+          "stl": 668,
+          "blk": 342,
+          "ba": 366,
+          "pf": 1310,
+          "pts": 8474,
+          "oppPts": 8682
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 975042,
+          "cash": 38039.68071139992,
+          "won": 35,
+          "lost": 47,
+          "wonHome": 20,
+          "lostHome": 21,
+          "wonAway": 15,
+          "lostAway": 26,
+          "wonDiv": 7,
+          "lostDiv": 9,
+          "wonConf": 14,
+          "lostConf": 38,
+          "lastTen": [
+            0,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0,
+            1,
+            0,
+            1
+          ],
+          "streak": -1,
+          "playoffRoundsWon": -1,
+          "hype": 0.5181824188538285,
+          "pop": 4,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 6785.367854530426,
+              "rank": 13
+            },
+            "sponsor": {
+              "amount": 22617.892848434756,
+              "rank": 13
+            },
+            "ticket": {
+              "amount": 71888.52716,
+              "rank": 11
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 22617.892848434756,
+              "rank": 13
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 59249.99999999992,
+              "rank": 13
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 14279.999999999993,
+              "rank": 13
+            },
+            "coaching": {
+              "amount": 14279.999999999993,
+              "rank": 13
+            },
+            "health": {
+              "amount": 14279.999999999993,
+              "rank": 13
+            },
+            "facilities": {
+              "amount": 14279.999999999993,
+              "rank": 13
+            }
+          },
+          "payrollEndOfSeason": 59250
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "39.66",
+          "rank": 13
+        },
+        "scouting": {
+          "amount": 14280,
+          "rank": 13
+        },
+        "coaching": {
+          "amount": 14280,
+          "rank": 13
+        },
+        "health": {
+          "amount": 14280,
+          "rank": 13
+        },
+        "facilities": {
+          "amount": 14280,
+          "rank": 13
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 16,
+      "cid": 0,
+      "did": 0,
+      "region": "New York",
+      "name": "Bankers",
+      "abbrev": "NYC",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19680.000000000062,
+          "fg": 2730,
+          "fga": 6948,
+          "fgAtRim": 795,
+          "fgaAtRim": 1447,
+          "fgLowPost": 676,
+          "fgaLowPost": 1548,
+          "fgMidRange": 841,
+          "fgaMidRange": 2579,
+          "tp": 418,
+          "tpa": 1374,
+          "ft": 1526,
+          "fta": 1987,
+          "orb": 784,
+          "drb": 2302,
+          "trb": 3086,
+          "ast": 1734,
+          "tov": 1100,
+          "stl": 503,
+          "blk": 265,
+          "ba": 354,
+          "pf": 1219,
+          "pts": 7404,
+          "oppPts": 9514
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 992049,
+          "cash": 80852.10939769106,
+          "won": 4,
+          "lost": 78,
+          "wonHome": 1,
+          "lostHome": 40,
+          "wonAway": 3,
+          "lostAway": 38,
+          "wonDiv": 0,
+          "lostDiv": 16,
+          "wonConf": 2,
+          "lostConf": 50,
+          "lastTen": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0
+          ],
+          "streak": -6,
+          "playoffRoundsWon": -1,
+          "hype": 0,
+          "pop": 18.7,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 10384.28277714964,
+              "rank": 3
+            },
+            "sponsor": {
+              "amount": 29736.378557287928,
+              "rank": 4
+            },
+            "ticket": {
+              "amount": 81661.62959999999,
+              "rank": 1
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 39305.42821935103,
+              "rank": 2
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 33975.609756097605,
+              "rank": 25
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 6000,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 17689.999999999985,
+              "rank": 2
+            },
+            "coaching": {
+              "amount": 17689.999999999985,
+              "rank": 2
+            },
+            "health": {
+              "amount": 17689.999999999985,
+              "rank": 2
+            },
+            "facilities": {
+              "amount": 17689.999999999985,
+              "rank": 2
+            }
+          },
+          "payrollEndOfSeason": 34000
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "49.14",
+          "rank": 2
+        },
+        "scouting": {
+          "amount": 17690,
+          "rank": 2
+        },
+        "coaching": {
+          "amount": 17690,
+          "rank": 2
+        },
+        "health": {
+          "amount": 17690,
+          "rank": 2
+        },
+        "facilities": {
+          "amount": 17690,
+          "rank": 2
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 17,
+      "cid": 0,
+      "did": 0,
+      "region": "Philadelphia",
+      "name": "Cheesesteaks",
+      "abbrev": "PHI",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19705.000000000076,
+          "fg": 3349,
+          "fga": 7194,
+          "fgAtRim": 838,
+          "fgaAtRim": 1330,
+          "fgLowPost": 942,
+          "fgaLowPost": 1822,
+          "fgMidRange": 875,
+          "fgaMidRange": 2267,
+          "tp": 694,
+          "tpa": 1775,
+          "ft": 1447,
+          "fta": 1869,
+          "orb": 838,
+          "drb": 2652,
+          "trb": 3490,
+          "ast": 2153,
+          "tov": 1148,
+          "stl": 676,
+          "blk": 336,
+          "ba": 358,
+          "pf": 1278,
+          "pts": 8839,
+          "oppPts": 8393
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 777757,
+          "cash": 22411.5628988122,
+          "won": 47,
+          "lost": 35,
+          "wonHome": 25,
+          "lostHome": 16,
+          "wonAway": 22,
+          "lostAway": 19,
+          "wonDiv": 10,
+          "lostDiv": 6,
+          "wonConf": 27,
+          "lostConf": 25,
+          "lastTen": [
+            0,
+            1,
+            0,
+            0,
+            0,
+            1,
+            1,
+            0,
+            1,
+            1
+          ],
+          "streak": -1,
+          "playoffRoundsWon": -1,
+          "hype": 0.5398274681488218,
+          "pop": 5.4,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 6142.1266615842005,
+              "rank": 15
+            },
+            "sponsor": {
+              "amount": 20473.755538613997,
+              "rank": 15
+            },
+            "ticket": {
+              "amount": 70371.92516,
+              "rank": 12
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 20473.755538613997,
+              "rank": 15
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 59750.00000000005,
+              "rank": 11
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 16450.00000000002,
+              "rank": 6
+            },
+            "coaching": {
+              "amount": 16450.00000000002,
+              "rank": 6
+            },
+            "health": {
+              "amount": 16450.00000000002,
+              "rank": 6
+            },
+            "facilities": {
+              "amount": 16450.00000000002,
+              "rank": 6
+            }
+          },
+          "payrollEndOfSeason": 59750
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "45.69",
+          "rank": 6
+        },
+        "scouting": {
+          "amount": 16450,
+          "rank": 6
+        },
+        "coaching": {
+          "amount": 16450,
+          "rank": 6
+        },
+        "health": {
+          "amount": 16450,
+          "rank": 6
+        },
+        "facilities": {
+          "amount": 16450,
+          "rank": 6
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 18,
+      "cid": 1,
+      "did": 3,
+      "region": "Phoenix",
+      "name": "Vultures",
+      "abbrev": "PHO",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19730.000000000025,
+          "fg": 3011,
+          "fga": 7034,
+          "fgAtRim": 935,
+          "fgaAtRim": 1587,
+          "fgLowPost": 946,
+          "fgaLowPost": 1931,
+          "fgMidRange": 691,
+          "fgaMidRange": 2175,
+          "tp": 439,
+          "tpa": 1341,
+          "ft": 1632,
+          "fta": 2193,
+          "orb": 1008,
+          "drb": 2700,
+          "trb": 3708,
+          "ast": 1822,
+          "tov": 1236,
+          "stl": 522,
+          "blk": 363,
+          "ba": 339,
+          "pf": 1221,
+          "pts": 8093,
+          "oppPts": 8464
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 459847,
+          "cash": 18962.83666102178,
+          "won": 37,
+          "lost": 45,
+          "wonHome": 24,
+          "lostHome": 17,
+          "wonAway": 13,
+          "lostAway": 28,
+          "wonDiv": 10,
+          "lostDiv": 6,
+          "wonConf": 26,
+          "lostConf": 26,
+          "lastTen": [
+            0,
+            0,
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          "streak": -3,
+          "playoffRoundsWon": 0,
+          "hype": 0.13292078334031177,
+          "pop": 3.4,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 4239.0772068352935,
+              "rank": 27
+            },
+            "sponsor": {
+              "amount": 14130.257356117645,
+              "rank": 27
+            },
+            "ticket": {
+              "amount": 49311.04962000003,
+              "rank": 27
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 14130.257356117645,
+              "rank": 27
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 32137.80487804876,
+              "rank": 27
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 7850,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 13339.999999999985,
+              "rank": 16
+            },
+            "coaching": {
+              "amount": 13339.999999999985,
+              "rank": 16
+            },
+            "health": {
+              "amount": 13339.999999999985,
+              "rank": 16
+            },
+            "facilities": {
+              "amount": 13339.999999999985,
+              "rank": 16
+            }
+          },
+          "payrollEndOfSeason": 32150
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "37.07",
+          "rank": 16
+        },
+        "scouting": {
+          "amount": 13340,
+          "rank": 16
+        },
+        "coaching": {
+          "amount": 13340,
+          "rank": 16
+        },
+        "health": {
+          "amount": 13340,
+          "rank": 16
+        },
+        "facilities": {
+          "amount": 13340,
+          "rank": 16
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 19,
+      "cid": 0,
+      "did": 1,
+      "region": "Pittsburgh",
+      "name": "Rivers",
+      "abbrev": "PIT",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19730.0000000001,
+          "fg": 2917,
+          "fga": 7186,
+          "fgAtRim": 635,
+          "fgaAtRim": 1078,
+          "fgLowPost": 728,
+          "fgaLowPost": 1559,
+          "fgMidRange": 984,
+          "fgaMidRange": 2820,
+          "tp": 570,
+          "tpa": 1729,
+          "ft": 1461,
+          "fta": 1846,
+          "orb": 955,
+          "drb": 2654,
+          "trb": 3609,
+          "ast": 1786,
+          "tov": 1219,
+          "stl": 583,
+          "blk": 350,
+          "ba": 375,
+          "pf": 1211,
+          "pts": 7865,
+          "oppPts": 8497
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 946393,
+          "cash": 37373.83567240833,
+          "won": 28,
+          "lost": 54,
+          "wonHome": 15,
+          "lostHome": 26,
+          "wonAway": 13,
+          "lostAway": 28,
+          "wonDiv": 7,
+          "lostDiv": 9,
+          "wonConf": 18,
+          "lostConf": 34,
+          "lastTen": [
+            1,
+            0,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0
+          ],
+          "streak": 1,
+          "playoffRoundsWon": -1,
+          "hype": 0.48975983380804317,
+          "pop": 1.8,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 5373.043704714983,
+              "rank": 20
+            },
+            "sponsor": {
+              "amount": 17910.14568238327,
+              "rank": 20
+            },
+            "ticket": {
+              "amount": 60872.20792000001,
+              "rank": 19
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 17910.14568238327,
+              "rank": 20
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 54231.70731707314,
+              "rank": 16
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 10239.999999999993,
+              "rank": 26
+            },
+            "coaching": {
+              "amount": 10239.999999999993,
+              "rank": 26
+            },
+            "health": {
+              "amount": 10239.999999999993,
+              "rank": 26
+            },
+            "facilities": {
+              "amount": 10239.999999999993,
+              "rank": 26
+            }
+          },
+          "payrollEndOfSeason": 54250
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "28.45",
+          "rank": 26
+        },
+        "scouting": {
+          "amount": 10240,
+          "rank": 26
+        },
+        "coaching": {
+          "amount": 10240,
+          "rank": 26
+        },
+        "health": {
+          "amount": 10240,
+          "rank": 26
+        },
+        "facilities": {
+          "amount": 10240,
+          "rank": 26
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 20,
+      "cid": 1,
+      "did": 4,
+      "region": "Portland",
+      "name": "Roses",
+      "abbrev": "POR",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19730.00000000002,
+          "fg": 3129,
+          "fga": 7210,
+          "fgAtRim": 755,
+          "fgaAtRim": 1207,
+          "fgLowPost": 824,
+          "fgaLowPost": 1670,
+          "fgMidRange": 920,
+          "fgaMidRange": 2519,
+          "tp": 630,
+          "tpa": 1814,
+          "ft": 1388,
+          "fta": 1769,
+          "orb": 846,
+          "drb": 2506,
+          "trb": 3352,
+          "ast": 1986,
+          "tov": 1123,
+          "stl": 598,
+          "blk": 315,
+          "ba": 365,
+          "pf": 1273,
+          "pts": 8276,
+          "oppPts": 8958
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 972320,
+          "cash": 24836.265962572583,
+          "won": 27,
+          "lost": 55,
+          "wonHome": 12,
+          "lostHome": 29,
+          "wonAway": 15,
+          "lostAway": 26,
+          "wonDiv": 7,
+          "lostDiv": 9,
+          "wonConf": 21,
+          "lostConf": 31,
+          "lastTen": [
+            0,
+            1,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+          ],
+          "streak": -1,
+          "playoffRoundsWon": -1,
+          "hype": 0.5941864695476026,
+          "pop": 1.8,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 5223.103150770333,
+              "rank": 23
+            },
+            "sponsor": {
+              "amount": 17410.34383590112,
+              "rank": 23
+            },
+            "ticket": {
+              "amount": 58562.475139999995,
+              "rank": 24
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 17410.34383590112,
+              "rank": 23
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 64549.99999999999,
+              "rank": 5
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 9929.999999999995,
+              "rank": 27
+            },
+            "coaching": {
+              "amount": 9929.999999999995,
+              "rank": 27
+            },
+            "health": {
+              "amount": 9929.999999999995,
+              "rank": 27
+            },
+            "facilities": {
+              "amount": 9929.999999999995,
+              "rank": 27
+            }
+          },
+          "payrollEndOfSeason": 64550
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "27.59",
+          "rank": 27
+        },
+        "scouting": {
+          "amount": 9930,
+          "rank": 27
+        },
+        "coaching": {
+          "amount": 9930,
+          "rank": 27
+        },
+        "health": {
+          "amount": 9930,
+          "rank": 27
+        },
+        "facilities": {
+          "amount": 9930,
+          "rank": 27
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 21,
+      "cid": 1,
+      "did": 5,
+      "region": "Sacramento",
+      "name": "Gold Rush",
+      "abbrev": "SAC",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19755.00000000003,
+          "fg": 2994,
+          "fga": 7154,
+          "fgAtRim": 858,
+          "fgaAtRim": 1425,
+          "fgLowPost": 553,
+          "fgaLowPost": 1227,
+          "fgMidRange": 967,
+          "fgaMidRange": 2703,
+          "tp": 616,
+          "tpa": 1799,
+          "ft": 1485,
+          "fta": 1900,
+          "orb": 840,
+          "drb": 2474,
+          "trb": 3314,
+          "ast": 1904,
+          "tov": 1100,
+          "stl": 621,
+          "blk": 267,
+          "ba": 349,
+          "pf": 1321,
+          "pts": 8089,
+          "oppPts": 9080
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 574196,
+          "cash": 19678.249370346693,
+          "won": 21,
+          "lost": 61,
+          "wonHome": 13,
+          "lostHome": 28,
+          "wonAway": 8,
+          "lostAway": 33,
+          "wonDiv": 6,
+          "lostDiv": 10,
+          "wonConf": 16,
+          "lostConf": 36,
+          "lastTen": [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          "streak": -10,
+          "playoffRoundsWon": -1,
+          "hype": 0,
+          "pop": 1.6,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 3985.507186492732,
+              "rank": 30
+            },
+            "sponsor": {
+              "amount": 13285.023954975763,
+              "rank": 30
+            },
+            "ticket": {
+              "amount": 47148.30403,
+              "rank": 30
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 13285.023954975763,
+              "rank": 30
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 52525.609756097576,
+              "rank": 17
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 9000.000000000013,
+              "rank": 30
+            },
+            "coaching": {
+              "amount": 9000.000000000013,
+              "rank": 30
+            },
+            "health": {
+              "amount": 9000.000000000013,
+              "rank": 30
+            },
+            "facilities": {
+              "amount": 9000.000000000013,
+              "rank": 30
+            }
+          },
+          "payrollEndOfSeason": 52550
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "25.00",
+          "rank": 30
+        },
+        "scouting": {
+          "amount": 9000,
+          "rank": 30
+        },
+        "coaching": {
+          "amount": 9000,
+          "rank": 30
+        },
+        "health": {
+          "amount": 9000,
+          "rank": 30
+        },
+        "facilities": {
+          "amount": 9000,
+          "rank": 30
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 22,
+      "cid": 1,
+      "did": 5,
+      "region": "San Diego",
+      "name": "Pandas",
+      "abbrev": "SD",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19680.00000000008,
+          "fg": 3271,
+          "fga": 7044,
+          "fgAtRim": 893,
+          "fgaAtRim": 1369,
+          "fgLowPost": 1043,
+          "fgaLowPost": 2044,
+          "fgMidRange": 762,
+          "fgaMidRange": 2190,
+          "tp": 573,
+          "tpa": 1441,
+          "ft": 1767,
+          "fta": 2210,
+          "orb": 999,
+          "drb": 3094,
+          "trb": 4093,
+          "ast": 1956,
+          "tov": 1217,
+          "stl": 730,
+          "blk": 436,
+          "ba": 344,
+          "pf": 1130,
+          "pts": 8882,
+          "oppPts": 7310
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 1023751,
+          "cash": 36761.160936779605,
+          "won": 69,
+          "lost": 13,
+          "wonHome": 36,
+          "lostHome": 5,
+          "wonAway": 33,
+          "lostAway": 8,
+          "wonDiv": 14,
+          "lostDiv": 2,
+          "wonConf": 45,
+          "lostConf": 7,
+          "lastTen": [
+            1,
+            1,
+            1,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "streak": 3,
+          "playoffRoundsWon": 0,
+          "hype": 1,
+          "pop": 2.9,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 6820.906075666903,
+              "rank": 11
+            },
+            "sponsor": {
+              "amount": 22736.35358555635,
+              "rank": 11
+            },
+            "ticket": {
+              "amount": 67547.54769,
+              "rank": 14
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 22736.35358555635,
+              "rank": 11
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 62700.000000000065,
+              "rank": 7
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 12720.000000000018,
+              "rank": 18
+            },
+            "coaching": {
+              "amount": 12720.000000000018,
+              "rank": 18
+            },
+            "health": {
+              "amount": 12720.000000000018,
+              "rank": 18
+            },
+            "facilities": {
+              "amount": 12720.000000000018,
+              "rank": 18
+            }
+          },
+          "payrollEndOfSeason": 62700
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "35.34",
+          "rank": 18
+        },
+        "scouting": {
+          "amount": 12720,
+          "rank": 18
+        },
+        "coaching": {
+          "amount": 12720,
+          "rank": 18
+        },
+        "health": {
+          "amount": 12720,
+          "rank": 18
+        },
+        "facilities": {
+          "amount": 12720,
+          "rank": 18
+        }
+      },
+      "strategy": "contending"
+    },
+    {
+      "tid": 23,
+      "cid": 1,
+      "did": 5,
+      "region": "San Francisco",
+      "name": "Venture Capitalists",
+      "abbrev": "SF",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19705.000000000044,
+          "fg": 3043,
+          "fga": 6925,
+          "fgAtRim": 893,
+          "fgaAtRim": 1511,
+          "fgLowPost": 854,
+          "fgaLowPost": 1716,
+          "fgMidRange": 784,
+          "fgaMidRange": 2311,
+          "tp": 512,
+          "tpa": 1387,
+          "ft": 1487,
+          "fta": 1937,
+          "orb": 846,
+          "drb": 2575,
+          "trb": 3421,
+          "ast": 1871,
+          "tov": 1198,
+          "stl": 598,
+          "blk": 319,
+          "ba": 331,
+          "pf": 1147,
+          "pts": 8085,
+          "oppPts": 8470
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 812717,
+          "cash": 30319.0473183802,
+          "won": 36,
+          "lost": 46,
+          "wonHome": 22,
+          "lostHome": 19,
+          "wonAway": 14,
+          "lostAway": 27,
+          "wonDiv": 9,
+          "lostDiv": 7,
+          "wonConf": 23,
+          "lostConf": 29,
+          "lastTen": [
+            1,
+            0,
+            0,
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0
+          ],
+          "streak": 1,
+          "playoffRoundsWon": 0,
+          "hype": 0.6096813821400898,
+          "pop": 3.4,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 5495.378649841739,
+              "rank": 19
+            },
+            "sponsor": {
+              "amount": 18317.9288328058,
+              "rank": 19
+            },
+            "ticket": {
+              "amount": 62159.518319999996,
+              "rank": 18
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 18317.9288328058,
+              "rank": 19
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 49831.70731707311,
+              "rank": 18
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 13659.99999999999,
+              "rank": 15
+            },
+            "coaching": {
+              "amount": 13659.99999999999,
+              "rank": 15
+            },
+            "health": {
+              "amount": 13659.99999999999,
+              "rank": 15
+            },
+            "facilities": {
+              "amount": 13659.99999999999,
+              "rank": 15
+            }
+          },
+          "payrollEndOfSeason": 49850
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "37.93",
+          "rank": 15
+        },
+        "scouting": {
+          "amount": 13660,
+          "rank": 15
+        },
+        "coaching": {
+          "amount": 13660,
+          "rank": 15
+        },
+        "health": {
+          "amount": 13660,
+          "rank": 15
+        },
+        "facilities": {
+          "amount": 13660,
+          "rank": 15
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 24,
+      "cid": 1,
+      "did": 4,
+      "region": "Seattle",
+      "name": "Symphony",
+      "abbrev": "SEA",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19755.000000000065,
+          "fg": 3240,
+          "fga": 7193,
+          "fgAtRim": 939,
+          "fgaAtRim": 1527,
+          "fgLowPost": 851,
+          "fgaLowPost": 1701,
+          "fgMidRange": 936,
+          "fgaMidRange": 2509,
+          "tp": 514,
+          "tpa": 1456,
+          "ft": 1558,
+          "fta": 2034,
+          "orb": 996,
+          "drb": 2666,
+          "trb": 3662,
+          "ast": 2001,
+          "tov": 1198,
+          "stl": 540,
+          "blk": 346,
+          "ba": 350,
+          "pf": 1213,
+          "pts": 8552,
+          "oppPts": 8684
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 1025000,
+          "cash": 44416.517342082036,
+          "won": 42,
+          "lost": 40,
+          "wonHome": 23,
+          "lostHome": 18,
+          "wonAway": 19,
+          "lostAway": 22,
+          "wonDiv": 7,
+          "lostDiv": 9,
+          "wonConf": 31,
+          "lostConf": 21,
+          "lastTen": [
+            0,
+            0,
+            1,
+            0,
+            1,
+            1,
+            1,
+            1,
+            0,
+            0
+          ],
+          "streak": -2,
+          "playoffRoundsWon": 0,
+          "hype": 0.9354312944459392,
+          "pop": 3,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 6794.9437646193965,
+              "rank": 12
+            },
+            "sponsor": {
+              "amount": 22649.812548731326,
+              "rank": 12
+            },
+            "ticket": {
+              "amount": 68891.94847999999,
+              "rank": 13
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 22649.812548731326,
+              "rank": 12
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 54949.999999999935,
+              "rank": 15
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 13030.000000000005,
+              "rank": 17
+            },
+            "coaching": {
+              "amount": 13030.000000000005,
+              "rank": 17
+            },
+            "health": {
+              "amount": 13030.000000000005,
+              "rank": 17
+            },
+            "facilities": {
+              "amount": 13030.000000000005,
+              "rank": 17
+            }
+          },
+          "payrollEndOfSeason": 54950
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "36.21",
+          "rank": 17
+        },
+        "scouting": {
+          "amount": 13030,
+          "rank": 17
+        },
+        "coaching": {
+          "amount": 13030,
+          "rank": 17
+        },
+        "health": {
+          "amount": 13030,
+          "rank": 17
+        },
+        "facilities": {
+          "amount": 13030,
+          "rank": 17
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 25,
+      "cid": 1,
+      "did": 3,
+      "region": "St. Louis",
+      "name": "Spirits",
+      "abbrev": "STL",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19680.00000000008,
+          "fg": 3058,
+          "fga": 6917,
+          "fgAtRim": 864,
+          "fgaAtRim": 1450,
+          "fgLowPost": 1032,
+          "fgaLowPost": 2089,
+          "fgMidRange": 857,
+          "fgaMidRange": 2502,
+          "tp": 305,
+          "tpa": 876,
+          "ft": 1768,
+          "fta": 2233,
+          "orb": 816,
+          "drb": 2633,
+          "trb": 3449,
+          "ast": 1912,
+          "tov": 1150,
+          "stl": 575,
+          "blk": 321,
+          "ba": 333,
+          "pf": 1244,
+          "pts": 8189,
+          "oppPts": 8483
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 860339,
+          "cash": 44484.93305335862,
+          "won": 35,
+          "lost": 47,
+          "wonHome": 19,
+          "lostHome": 22,
+          "wonAway": 16,
+          "lostAway": 25,
+          "wonDiv": 4,
+          "lostDiv": 12,
+          "wonConf": 25,
+          "lostConf": 27,
+          "lastTen": [
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            1,
+            1,
+            1,
+            0
+          ],
+          "streak": -2,
+          "playoffRoundsWon": -1,
+          "hype": 0.5298661199064701,
+          "pop": 2.2,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 5138.20513545399,
+              "rank": 24
+            },
+            "sponsor": {
+              "amount": 17127.350451513306,
+              "rank": 24
+            },
+            "ticket": {
+              "amount": 59241.53921,
+              "rank": 23
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 17127.350451513306,
+              "rank": 24
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 34869.51219512197,
+              "rank": 24
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 5100,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 11170.000000000007,
+              "rank": 23
+            },
+            "coaching": {
+              "amount": 11170.000000000007,
+              "rank": 23
+            },
+            "health": {
+              "amount": 11170.000000000007,
+              "rank": 23
+            },
+            "facilities": {
+              "amount": 11170.000000000007,
+              "rank": 23
+            }
+          },
+          "payrollEndOfSeason": 34900
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "31.03",
+          "rank": 23
+        },
+        "scouting": {
+          "amount": 11170,
+          "rank": 23
+        },
+        "coaching": {
+          "amount": 11170,
+          "rank": 23
+        },
+        "health": {
+          "amount": 11170,
+          "rank": 23
+        },
+        "facilities": {
+          "amount": 11170,
+          "rank": 23
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 26,
+      "cid": 0,
+      "did": 2,
+      "region": "Tampa",
+      "name": "Turtles",
+      "abbrev": "TPA",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19705,
+          "fg": 3286,
+          "fga": 7130,
+          "fgAtRim": 1088,
+          "fgaAtRim": 1708,
+          "fgLowPost": 869,
+          "fgaLowPost": 1766,
+          "fgMidRange": 645,
+          "fgaMidRange": 1846,
+          "tp": 684,
+          "tpa": 1810,
+          "ft": 1567,
+          "fta": 1938,
+          "orb": 978,
+          "drb": 2899,
+          "trb": 3877,
+          "ast": 2065,
+          "tov": 1246,
+          "stl": 727,
+          "blk": 401,
+          "ba": 333,
+          "pf": 1144,
+          "pts": 8823,
+          "oppPts": 7677
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 979779,
+          "cash": 37701.97131503867,
+          "won": 66,
+          "lost": 16,
+          "wonHome": 35,
+          "lostHome": 6,
+          "wonAway": 31,
+          "lostAway": 10,
+          "wonDiv": 9,
+          "lostDiv": 7,
+          "wonConf": 41,
+          "lostConf": 11,
+          "lastTen": [
+            0,
+            0,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0
+          ],
+          "streak": -3,
+          "playoffRoundsWon": 0,
+          "hype": 1,
+          "pop": 2.2,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 5947.465006086699,
+              "rank": 16
+            },
+            "sponsor": {
+              "amount": 19824.88335362233,
+              "rank": 16
+            },
+            "ticket": {
+              "amount": 64371.56887,
+              "rank": 17
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 19824.88335362233,
+              "rank": 16
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 59326.82926829266,
+              "rank": 12
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 10859.999999999982,
+              "rank": 24
+            },
+            "coaching": {
+              "amount": 10859.999999999982,
+              "rank": 24
+            },
+            "health": {
+              "amount": 10859.999999999982,
+              "rank": 24
+            },
+            "facilities": {
+              "amount": 10859.999999999982,
+              "rank": 24
+            }
+          },
+          "payrollEndOfSeason": 59400
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "30.17",
+          "rank": 24
+        },
+        "scouting": {
+          "amount": 10860,
+          "rank": 24
+        },
+        "coaching": {
+          "amount": 10860,
+          "rank": 24
+        },
+        "health": {
+          "amount": 10860,
+          "rank": 24
+        },
+        "facilities": {
+          "amount": 10860,
+          "rank": 24
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 27,
+      "cid": 0,
+      "did": 0,
+      "region": "Toronto",
+      "name": "Beavers",
+      "abbrev": "TOR",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19730.00000000002,
+          "fg": 3376,
+          "fga": 7286,
+          "fgAtRim": 847,
+          "fgaAtRim": 1333,
+          "fgLowPost": 916,
+          "fgaLowPost": 1717,
+          "fgMidRange": 953,
+          "fgaMidRange": 2481,
+          "tp": 660,
+          "tpa": 1755,
+          "ft": 1527,
+          "fta": 1946,
+          "orb": 904,
+          "drb": 2931,
+          "trb": 3835,
+          "ast": 2154,
+          "tov": 1155,
+          "stl": 740,
+          "blk": 369,
+          "ba": 352,
+          "pf": 1278,
+          "pts": 8939,
+          "oppPts": 7914
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 1025000,
+          "cash": 66095.24096918566,
+          "won": 65,
+          "lost": 17,
+          "wonHome": 36,
+          "lostHome": 5,
+          "wonAway": 29,
+          "lostAway": 12,
+          "wonDiv": 13,
+          "lostDiv": 3,
+          "wonConf": 38,
+          "lostConf": 14,
+          "lastTen": [
+            1,
+            1,
+            1,
+            0,
+            1,
+            0,
+            1,
+            1,
+            0,
+            1
+          ],
+          "streak": 3,
+          "playoffRoundsWon": 0,
+          "hype": 1,
+          "pop": 6.3,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 11268.032272184066,
+              "rank": 2
+            },
+            "sponsor": {
+              "amount": 33351.1656030547,
+              "rank": 1
+            },
+            "ticket": {
+              "amount": 81105.93552000001,
+              "rank": 3
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 37560.10757394689,
+              "rank": 3
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 60650.000000000065,
+              "rank": 9
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 16759.99999999998,
+              "rank": 5
+            },
+            "coaching": {
+              "amount": 16759.99999999998,
+              "rank": 5
+            },
+            "health": {
+              "amount": 16759.99999999998,
+              "rank": 5
+            },
+            "facilities": {
+              "amount": 16759.99999999998,
+              "rank": 5
+            }
+          },
+          "payrollEndOfSeason": 60650
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "46.55",
+          "rank": 5
+        },
+        "scouting": {
+          "amount": 16760,
+          "rank": 5
+        },
+        "coaching": {
+          "amount": 16760,
+          "rank": 5
+        },
+        "health": {
+          "amount": 16760,
+          "rank": 5
+        },
+        "facilities": {
+          "amount": 16760,
+          "rank": 5
+        }
+      },
+      "strategy": "contending"
+    },
+    {
+      "tid": 28,
+      "cid": 1,
+      "did": 4,
+      "region": "Vancouver",
+      "name": "Whalers",
+      "abbrev": "VAN",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19680.00000000007,
+          "fg": 2815,
+          "fga": 6951,
+          "fgAtRim": 805,
+          "fgaAtRim": 1371,
+          "fgLowPost": 683,
+          "fgaLowPost": 1519,
+          "fgMidRange": 821,
+          "fgaMidRange": 2496,
+          "tp": 506,
+          "tpa": 1565,
+          "ft": 1593,
+          "fta": 2090,
+          "orb": 759,
+          "drb": 2401,
+          "trb": 3160,
+          "ast": 1766,
+          "tov": 1161,
+          "stl": 443,
+          "blk": 261,
+          "ba": 334,
+          "pf": 1212,
+          "pts": 7729,
+          "oppPts": 9474
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 494481,
+          "cash": 22930.686858580142,
+          "won": 10,
+          "lost": 72,
+          "wonHome": 6,
+          "lostHome": 35,
+          "wonAway": 4,
+          "lostAway": 37,
+          "wonDiv": 1,
+          "lostDiv": 15,
+          "wonConf": 8,
+          "lostConf": 44,
+          "lastTen": [
+            1,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0
+          ],
+          "streak": 2,
+          "playoffRoundsWon": -1,
+          "hype": 0,
+          "pop": 2.3,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 4165.522765392742,
+              "rank": 28
+            },
+            "sponsor": {
+              "amount": 13885.075884642476,
+              "rank": 28
+            },
+            "ticket": {
+              "amount": 48870.62208000001,
+              "rank": 28
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 13885.075884642476,
+              "rank": 28
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 27875.609756097605,
+              "rank": 29
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 12100,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 12100.00000000002,
+              "rank": 20
+            },
+            "coaching": {
+              "amount": 12100.00000000002,
+              "rank": 20
+            },
+            "health": {
+              "amount": 12100.00000000002,
+              "rank": 20
+            },
+            "facilities": {
+              "amount": 12100.00000000002,
+              "rank": 20
+            }
+          },
+          "payrollEndOfSeason": 27900
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "33.62",
+          "rank": 20
+        },
+        "scouting": {
+          "amount": 12100,
+          "rank": 20
+        },
+        "coaching": {
+          "amount": 12100,
+          "rank": 20
+        },
+        "health": {
+          "amount": 12100,
+          "rank": 20
+        },
+        "facilities": {
+          "amount": 12100,
+          "rank": 20
+        }
+      },
+      "strategy": "rebuilding"
+    },
+    {
+      "tid": 29,
+      "cid": 0,
+      "did": 2,
+      "region": "Washington",
+      "name": "Monuments",
+      "abbrev": "WAS",
+      "imgURL": "",
+      "stats": [
+        {
+          "season": 2015,
+          "playoffs": false,
+          "gp": 82,
+          "min": 19780.000000000065,
+          "fg": 3258,
+          "fga": 7124,
+          "fgAtRim": 956,
+          "fgaAtRim": 1515,
+          "fgLowPost": 987,
+          "fgaLowPost": 1950,
+          "fgMidRange": 775,
+          "fgaMidRange": 2168,
+          "tp": 540,
+          "tpa": 1491,
+          "ft": 1640,
+          "fta": 2080,
+          "orb": 859,
+          "drb": 2804,
+          "trb": 3663,
+          "ast": 2036,
+          "tov": 1069,
+          "stl": 700,
+          "blk": 358,
+          "ba": 327,
+          "pf": 1202,
+          "pts": 8696,
+          "oppPts": 7951
+        },
+        {
+          "season": 2015,
+          "playoffs": true,
+          "gp": 0,
+          "min": 0,
+          "fg": 0,
+          "fga": 0,
+          "fgAtRim": 0,
+          "fgaAtRim": 0,
+          "fgLowPost": 0,
+          "fgaLowPost": 0,
+          "fgMidRange": 0,
+          "fgaMidRange": 0,
+          "tp": 0,
+          "tpa": 0,
+          "ft": 0,
+          "fta": 0,
+          "orb": 0,
+          "drb": 0,
+          "trb": 0,
+          "ast": 0,
+          "tov": 0,
+          "stl": 0,
+          "blk": 0,
+          "ba": 0,
+          "pf": 0,
+          "pts": 0,
+          "oppPts": 0
+        }
+      ],
+      "seasons": [
+        {
+          "season": 2015,
+          "gp": 82,
+          "gpHome": 41,
+          "att": 1005222,
+          "cash": 39418.06159230258,
+          "won": 61,
+          "lost": 21,
+          "wonHome": 35,
+          "lostHome": 6,
+          "wonAway": 26,
+          "lostAway": 15,
+          "wonDiv": 13,
+          "lostDiv": 3,
+          "wonConf": 37,
+          "lostConf": 15,
+          "lastTen": [
+            0,
+            0,
+            0,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1
+          ],
+          "streak": -3,
+          "playoffRoundsWon": 0,
+          "hype": 1,
+          "pop": 4.2,
+          "tvContract": {
+            "amount": 0,
+            "exp": 0
+          },
+          "revenues": {
+            "merch": {
+              "amount": 7558.653681169904,
+              "rank": 6
+            },
+            "sponsor": {
+              "amount": 25195.512270566345,
+              "rank": 6
+            },
+            "ticket": {
+              "amount": 74028.38337000001,
+              "rank": 8
+            },
+            "nationalTv": {
+              "amount": 20500,
+              "rank": 1
+            },
+            "localTv": {
+              "amount": 25195.512270566345,
+              "rank": 6
+            }
+          },
+          "expenses": {
+            "salary": {
+              "amount": 64700.00000000006,
+              "rank": 4
+            },
+            "luxuryTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "minTax": {
+              "amount": 0,
+              "rank": 1
+            },
+            "buyOuts": {
+              "amount": 0,
+              "rank": 1
+            },
+            "scouting": {
+              "amount": 14589.999999999973,
+              "rank": 12
+            },
+            "coaching": {
+              "amount": 14589.999999999973,
+              "rank": 12
+            },
+            "health": {
+              "amount": 14589.999999999973,
+              "rank": 12
+            },
+            "facilities": {
+              "amount": 14589.999999999973,
+              "rank": 12
+            }
+          },
+          "payrollEndOfSeason": 64700
+        }
+      ],
+      "budget": {
+        "ticketPrice": {
+          "amount": "40.52",
+          "rank": 12
+        },
+        "scouting": {
+          "amount": 14590,
+          "rank": 12
+        },
+        "coaching": {
+          "amount": 14590,
+          "rank": 12
+        },
+        "health": {
+          "amount": 14590,
+          "rank": 12
+        },
+        "facilities": {
+          "amount": 14590,
+          "rank": 12
+        }
+      },
+      "strategy": "contending"
+    }
+  ]
+}

--- a/js/core/phase.js
+++ b/js/core/phase.js
@@ -168,153 +168,22 @@ define(["dao", "globals", "ui", "core/contractNegotiation", "core/draft", "core/
         account.checkAchievement.septuawinarian();
 
         // Set playoff matchups
-        return team.filter({
-            ot: tx,
-            attrs: ["tid", "cid", "region"],
-            seasonAttrs: ["winp"],
-            season: g.season,
-            sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
-        }).then(function (teams) {
-            var cid, i, series, teamsConf, tidPlayoffs;
+        return season.createPlayoffMatchups(tx)
+            .then(function () {
+                return Promise.all([
+                    finances.assessPayrollMinLuxury(tx),
+                    season.newSchedulePlayoffsDay(tx)
+                ]);
+            }).then(function () {
+                var url;
 
-            // Add entry for wins for each team; delete winp, which was only needed for sorting
-            for (i = 0; i < teams.length; i++) {
-                teams[i].won = 0;
-            }
-
-            if (!localStorage.top16playoffs || true) {
-                // Default: top 8 teams in each conference
-                tidPlayoffs = [];
-                series = [[], [], [], []];  // First round, second round, third round, fourth round
-                for (cid = 0; cid < 2; cid++) {
-                    teamsConf = [];
-                    for (i = 0; i < teams.length; i++) {
-                        if (teams[i].cid === cid) {
-                            if (teamsConf.length < 8) {
-                                teamsConf.push(teams[i]);
-                                tidPlayoffs.push(teams[i].tid);
-                            }
-                        }
-                    }
-
-                    helpers.seriesHomeAway(series, teamsConf, 1, 8, 0, cid);
-                    helpers.seriesHomeAway(series, teamsConf, 4, 5, 1, cid);
-                    helpers.seriesHomeAway(series, teamsConf, 3, 6, 2, cid);
-                    helpers.seriesHomeAway(series, teamsConf, 2, 7, 3, cid);
+                // Don't redirect if we're viewing a live game now
+                if (location.pathname.indexOf("/live_game") === -1) {
+                    url = helpers.leagueUrl(["playoffs"]);
                 }
-            } else {
-                // Alternative (localStorage.top16playoffs): top 16 teams overall
-                tidPlayoffs = [];
-                series = [[], [], [], []];  // First round, second round, third round, fourth round
-                teamsConf = [];
-                for (i = 0; i < teams.length; i++) {
-                    if (teamsConf.length < 16) {
-                        teamsConf.push(teams[i]);
-                        tidPlayoffs.push(teams[i].tid);
-                    }
-                }
-                series[0][0] = {home: teamsConf[0], away: teamsConf[15]};
-                series[0][0].home.seed = 1;
-                series[0][0].away.seed = 16;
-                series[0][1] = {home: teamsConf[7], away: teamsConf[8]};
-                series[0][1].home.seed = 8;
-                series[0][1].away.seed = 9;
-                series[0][2] = {home: teamsConf[3], away: teamsConf[12]};
-                series[0][2].home.seed = 4;
-                series[0][2].away.seed = 13;
-                series[0][3] = {home: teamsConf[4], away: teamsConf[11]};
-                series[0][3].home.seed = 5;
-                series[0][3].away.seed = 12;
-                series[0][4] = {home: teamsConf[1], away: teamsConf[14]};
-                series[0][4].home.seed = 2;
-                series[0][4].away.seed = 15;
-                series[0][5] = {home: teamsConf[6], away: teamsConf[9]};
-                series[0][5].home.seed = 7;
-                series[0][5].away.seed = 10;
-                series[0][6] = {home: teamsConf[2], away: teamsConf[13]};
-                series[0][6].home.seed = 3;
-                series[0][6].away.seed = 14;
-                series[0][7] = {home: teamsConf[5], away: teamsConf[10]};
-                series[0][7].home.seed = 6;
-                series[0][7].away.seed = 11;
-            }
 
-            tidPlayoffs.forEach(function (tid) {
-                eventLog.add(null, {
-                    type: "playoffs",
-                    text: 'The <a href="' + helpers.leagueUrl(["roster", g.teamAbbrevsCache[tid], g.season]) + '">' + g.teamNamesCache[tid] + '</a> made the <a href="' + helpers.leagueUrl(["playoffs", g.season]) + '">playoffs</a>.',
-                    showNotification: tid === g.userTid,
-                    tids: [tid]
-                });
+                return [url, ["teamFinances"]];
             });
-
-            return Promise.all([
-                dao.playoffSeries.put({
-                    ot: tx,
-                    value: {
-                        season: g.season,
-                        currentRound: 0,
-                        series: series
-                    }
-                }),
-
-                // Add row to team stats and team season attributes
-                dao.teams.iterate({
-                    ot: tx,
-                    callback: function (t) {
-                        var teamSeason;
-
-                        teamSeason = t.seasons[t.seasons.length - 1];
-
-                        if (tidPlayoffs.indexOf(t.tid) >= 0) {
-                            t = team.addStatsRow(t, true);
-
-                            teamSeason.playoffRoundsWon = 0;
-
-                            // More hype for making the playoffs
-                            teamSeason.hype += 0.05;
-                            if (teamSeason.hype > 1) {
-                                teamSeason.hype = 1;
-                            }
-                        } else {
-                            // Less hype for missing the playoffs
-                            teamSeason.hype -= 0.05;
-                            if (teamSeason.hype < 0) {
-                                teamSeason.hype = 0;
-                            }
-                        }
-
-                        return t;
-                    }
-                }),
-
-                // Add row to player stats
-                Promise.map(tidPlayoffs, function (tid) {
-                    return dao.players.iterate({
-                        ot: tx,
-                        index: "tid",
-                        key: tid,
-                        callback: function (p) {
-                            return player.addStatsRow(tx, p, true);
-                        }
-                    });
-                }, {concurrency: Infinity})
-            ]);
-        }).then(function () {
-            return Promise.all([
-                finances.assessPayrollMinLuxury(tx),
-                season.newSchedulePlayoffsDay(tx)
-            ]);
-        }).then(function () {
-            var url;
-
-            // Don't redirect if we're viewing a live game now
-            if (location.pathname.indexOf("/live_game") === -1) {
-                url = helpers.leagueUrl(["playoffs"]);
-            }
-
-            return [url, ["teamFinances"]];
-        });
     }
 
     function newPhaseBeforeDraft(tx) {

--- a/js/core/phase.js
+++ b/js/core/phase.js
@@ -170,7 +170,7 @@ define(["dao", "globals", "ui", "core/contractNegotiation", "core/draft", "core/
         // Set playoff matchups
         return team.filter({
             ot: tx,
-            attrs: ["tid", "cid"],
+            attrs: ["tid", "cid", "region"],
             seasonAttrs: ["winp"],
             season: g.season,
             sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
@@ -182,7 +182,7 @@ define(["dao", "globals", "ui", "core/contractNegotiation", "core/draft", "core/
                 teams[i].won = 0;
             }
 
-            if (!localStorage.top16playoffs) {
+            if (!localStorage.top16playoffs || true) {
                 // Default: top 8 teams in each conference
                 tidPlayoffs = [];
                 series = [[], [], [], []];  // First round, second round, third round, fourth round
@@ -196,18 +196,11 @@ define(["dao", "globals", "ui", "core/contractNegotiation", "core/draft", "core/
                             }
                         }
                     }
-                    series[0][cid * 4] = {home: teamsConf[0], away: teamsConf[7]};
-                    series[0][cid * 4].home.seed = 1;
-                    series[0][cid * 4].away.seed = 8;
-                    series[0][1 + cid * 4] = {home: teamsConf[3], away: teamsConf[4]};
-                    series[0][1 + cid * 4].home.seed = 4;
-                    series[0][1 + cid * 4].away.seed = 5;
-                    series[0][2 + cid * 4] = {home: teamsConf[2], away: teamsConf[5]};
-                    series[0][2 + cid * 4].home.seed = 3;
-                    series[0][2 + cid * 4].away.seed = 6;
-                    series[0][3 + cid * 4] = {home: teamsConf[1], away: teamsConf[6]};
-                    series[0][3 + cid * 4].home.seed = 2;
-                    series[0][3 + cid * 4].away.seed = 7;
+
+                    helpers.seriesHomeAway(series, teamsConf, 1, 8, 0, cid);
+                    helpers.seriesHomeAway(series, teamsConf, 4, 5, 1, cid);
+                    helpers.seriesHomeAway(series, teamsConf, 3, 6, 2, cid);
+                    helpers.seriesHomeAway(series, teamsConf, 2, 7, 3, cid);
                 }
             } else {
                 // Alternative (localStorage.top16playoffs): top 16 teams overall

--- a/js/core/phase.js
+++ b/js/core/phase.js
@@ -173,7 +173,7 @@ define(["dao", "globals", "ui", "core/contractNegotiation", "core/draft", "core/
             attrs: ["tid", "cid"],
             seasonAttrs: ["winp"],
             season: g.season,
-            sortBy: "winp"
+            sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
         }).then(function (teams) {
             var cid, i, series, teamsConf, tidPlayoffs;
 

--- a/js/core/season.js
+++ b/js/core/season.js
@@ -704,7 +704,7 @@ define(["dao", "globals", "core/player", "core/team", "lib/bluebird", "lib/under
             attrs: ["tid", "cid", "region"],
             seasonAttrs: ["winp"],
             season: g.season,
-            sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
+            sortBy: helpers.getPlayoffSorting()
         }).then(function (teams) {
             var cid, i, series, teamsConf, tidPlayoffs;
 

--- a/js/core/season.js
+++ b/js/core/season.js
@@ -597,7 +597,7 @@ define(["dao", "globals", "core/player", "core/team", "lib/bluebird", "lib/under
                 }
             }
         }).then(function () {
-            var i, key, matchup, team1, team2, tidsWon;
+            var i, key, matchup, team1, team2, tidsWon, sorter, sortBy, ts;
 
             // Now playoffSeries, rnd, series, and tids are set
 
@@ -659,11 +659,13 @@ define(["dao", "globals", "core/player", "core/team", "lib/bluebird", "lib/under
                 }
 
                 // Set home/away in the next round
-                if (team1.winp > team2.winp) {
-                    matchup = {home: team1, away: team2};
-                } else {
-                    matchup = {home: team2, away: team1};
-                }
+                sortBy = ['winp', 'cwinp', 'ocwinp', 'diff'];
+                sorter = new helpers.MultiSort(sortBy);
+                ts = [team1, team2];
+                ts.sort(sorter.sortF);
+
+                matchup = {home: ts[0], away: ts[1]};
+                console.log(matchup);
 
                 matchup.home.won = 0;
                 matchup.away.won = 0;

--- a/js/core/season.js
+++ b/js/core/season.js
@@ -660,9 +660,9 @@ define(["dao", "globals", "core/player", "core/team", "lib/bluebird", "lib/under
 
                 // Set home/away in the next round
                 sortBy = ['winp', 'cwinp', 'ocwinp', 'diff'];
-                sorter = new helpers.MultiSort(sortBy);
+                sorter = helpers.multiSort(sortBy);
                 ts = [team1, team2];
-                ts.sort(sorter.sortF);
+                ts.sort(sorter);
 
                 matchup = {home: ts[0], away: ts[1]};
 

--- a/js/core/season.js
+++ b/js/core/season.js
@@ -98,7 +98,7 @@ define(["dao", "globals", "core/player", "core/team", "lib/bluebird", "lib/under
             attrs: ["tid", "abbrev", "region", "name", "cid"],
             seasonAttrs: ["won", "lost", "winp", "playoffRoundsWon"],
             season: g.season,
-            sortBy: "winp",
+            sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"],
             ot: tx
         }).then(function (teams) {
             var foundEast, foundWest, i, t;

--- a/js/core/season.js
+++ b/js/core/season.js
@@ -698,6 +698,142 @@ define(["dao", "globals", "core/player", "core/team", "lib/bluebird", "lib/under
         });
     }
 
+    function createPlayoffMatchups(tx) {
+        return team.filter({
+            ot: tx,
+            attrs: ["tid", "cid", "region"],
+            seasonAttrs: ["winp"],
+            season: g.season,
+            sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
+        }).then(function (teams) {
+            var cid, i, series, teamsConf, tidPlayoffs;
+
+            // Add entry for wins for each team; delete winp, which was only needed for sorting
+            for (i = 0; i < teams.length; i++) {
+                teams[i].won = 0;
+            }
+
+            if (!localStorage.top16playoffs || true) {
+                // Default: top 8 teams in each conference
+                tidPlayoffs = [];
+                series = [[], [], [], []];  // First round, second round, third round, fourth round
+                for (cid = 0; cid < 2; cid++) {
+                    teamsConf = [];
+                    for (i = 0; i < teams.length; i++) {
+                        if (teams[i].cid === cid) {
+                            if (teamsConf.length < 8) {
+                                teamsConf.push(teams[i]);
+                                tidPlayoffs.push(teams[i].tid);
+                            }
+                        }
+                    }
+
+                    helpers.seriesHomeAway(series, teamsConf, 1, 8, 0, cid);
+                    helpers.seriesHomeAway(series, teamsConf, 4, 5, 1, cid);
+                    helpers.seriesHomeAway(series, teamsConf, 3, 6, 2, cid);
+                    helpers.seriesHomeAway(series, teamsConf, 2, 7, 3, cid);
+                }
+            } else {
+                // Alternative (localStorage.top16playoffs): top 16 teams overall
+                tidPlayoffs = [];
+                series = [[], [], [], []];  // First round, second round, third round, fourth round
+                teamsConf = [];
+                for (i = 0; i < teams.length; i++) {
+                    if (teamsConf.length < 16) {
+                        teamsConf.push(teams[i]);
+                        tidPlayoffs.push(teams[i].tid);
+                    }
+                }
+                series[0][0] = {home: teamsConf[0], away: teamsConf[15]};
+                series[0][0].home.seed = 1;
+                series[0][0].away.seed = 16;
+                series[0][1] = {home: teamsConf[7], away: teamsConf[8]};
+                series[0][1].home.seed = 8;
+                series[0][1].away.seed = 9;
+                series[0][2] = {home: teamsConf[3], away: teamsConf[12]};
+                series[0][2].home.seed = 4;
+                series[0][2].away.seed = 13;
+                series[0][3] = {home: teamsConf[4], away: teamsConf[11]};
+                series[0][3].home.seed = 5;
+                series[0][3].away.seed = 12;
+                series[0][4] = {home: teamsConf[1], away: teamsConf[14]};
+                series[0][4].home.seed = 2;
+                series[0][4].away.seed = 15;
+                series[0][5] = {home: teamsConf[6], away: teamsConf[9]};
+                series[0][5].home.seed = 7;
+                series[0][5].away.seed = 10;
+                series[0][6] = {home: teamsConf[2], away: teamsConf[13]};
+                series[0][6].home.seed = 3;
+                series[0][6].away.seed = 14;
+                series[0][7] = {home: teamsConf[5], away: teamsConf[10]};
+                series[0][7].home.seed = 6;
+                series[0][7].away.seed = 11;
+            }
+
+            tidPlayoffs.forEach(function (tid) {
+                eventLog.add(null, {
+                    type: "playoffs",
+                    text: 'The <a href="' + helpers.leagueUrl(["roster", g.teamAbbrevsCache[tid], g.season]) + '">' + g.teamNamesCache[tid] + '</a> made the <a href="' + helpers.leagueUrl(["playoffs", g.season]) + '">playoffs</a>.',
+                    showNotification: tid === g.userTid,
+                    tids: [tid]
+                });
+            });
+
+            return Promise.all([
+                dao.playoffSeries.put({
+                    ot: tx,
+                    value: {
+                        season: g.season,
+                        currentRound: 0,
+                        series: series
+                    }
+                }),
+
+                // Add row to team stats and team season attributes
+                dao.teams.iterate({
+                    ot: tx,
+                    callback: function (t) {
+                        var teamSeason;
+
+                        teamSeason = t.seasons[t.seasons.length - 1];
+
+                        if (tidPlayoffs.indexOf(t.tid) >= 0) {
+                            t = team.addStatsRow(t, true);
+
+                            teamSeason.playoffRoundsWon = 0;
+
+                            // More hype for making the playoffs
+                            teamSeason.hype += 0.05;
+                            if (teamSeason.hype > 1) {
+                                teamSeason.hype = 1;
+                            }
+                        } else {
+                            // Less hype for missing the playoffs
+                            teamSeason.hype -= 0.05;
+                            if (teamSeason.hype < 0) {
+                                teamSeason.hype = 0;
+                            }
+                        }
+
+                        return t;
+                    }
+                }),
+
+                // Add row to player stats
+                Promise.map(tidPlayoffs, function (tid) {
+                    return dao.players.iterate({
+                        ot: tx,
+                        index: "tid",
+                        key: tid,
+                        callback: function (p) {
+                            return player.addStatsRow(tx, p, true);
+                        }
+                    });
+                }, {concurrency: Infinity})
+            ]);
+        });
+    }
+
     /**
      * Get the number of days left in the regular season schedule.
      *
@@ -736,6 +872,7 @@ define(["dao", "globals", "core/player", "core/team", "lib/bluebird", "lib/under
         setSchedule: setSchedule,
         newSchedule: newSchedule,
         newSchedulePlayoffsDay: newSchedulePlayoffsDay,
-        getDaysLeftSchedule: getDaysLeftSchedule
+        getDaysLeftSchedule: getDaysLeftSchedule,
+        createPlayoffMatchups: createPlayoffMatchups
     };
 });

--- a/js/core/season.js
+++ b/js/core/season.js
@@ -713,7 +713,7 @@ define(["dao", "globals", "core/player", "core/team", "lib/bluebird", "lib/under
                 teams[i].won = 0;
             }
 
-            if (!localStorage.top16playoffs || true) {
+            if (!localStorage.top16playoffs) {
                 // Default: top 8 teams in each conference
                 tidPlayoffs = [];
                 series = [[], [], [], []];  // First round, second round, third round, fourth round
@@ -744,30 +744,14 @@ define(["dao", "globals", "core/player", "core/team", "lib/bluebird", "lib/under
                         tidPlayoffs.push(teams[i].tid);
                     }
                 }
-                series[0][0] = {home: teamsConf[0], away: teamsConf[15]};
-                series[0][0].home.seed = 1;
-                series[0][0].away.seed = 16;
-                series[0][1] = {home: teamsConf[7], away: teamsConf[8]};
-                series[0][1].home.seed = 8;
-                series[0][1].away.seed = 9;
-                series[0][2] = {home: teamsConf[3], away: teamsConf[12]};
-                series[0][2].home.seed = 4;
-                series[0][2].away.seed = 13;
-                series[0][3] = {home: teamsConf[4], away: teamsConf[11]};
-                series[0][3].home.seed = 5;
-                series[0][3].away.seed = 12;
-                series[0][4] = {home: teamsConf[1], away: teamsConf[14]};
-                series[0][4].home.seed = 2;
-                series[0][4].away.seed = 15;
-                series[0][5] = {home: teamsConf[6], away: teamsConf[9]};
-                series[0][5].home.seed = 7;
-                series[0][5].away.seed = 10;
-                series[0][6] = {home: teamsConf[2], away: teamsConf[13]};
-                series[0][6].home.seed = 3;
-                series[0][6].away.seed = 14;
-                series[0][7] = {home: teamsConf[5], away: teamsConf[10]};
-                series[0][7].home.seed = 6;
-                series[0][7].away.seed = 11;
+                helpers.seriesHomeAway(series, teamsConf, 1, 16, 0, 0);
+                helpers.seriesHomeAway(series, teamsConf, 8, 9, 1, 0);
+                helpers.seriesHomeAway(series, teamsConf, 4, 13, 2, 0);
+                helpers.seriesHomeAway(series, teamsConf, 5, 12, 3, 0);
+                helpers.seriesHomeAway(series, teamsConf, 2, 15, 4, 0);
+                helpers.seriesHomeAway(series, teamsConf, 7, 10, 5, 0);
+                helpers.seriesHomeAway(series, teamsConf, 3, 14, 6, 0);
+                helpers.seriesHomeAway(series, teamsConf, 6, 11, 7, 0);
             }
 
             tidPlayoffs.forEach(function (tid) {

--- a/js/core/season.js
+++ b/js/core/season.js
@@ -665,7 +665,6 @@ define(["dao", "globals", "core/player", "core/team", "lib/bluebird", "lib/under
                 ts.sort(sorter.sortF);
 
                 matchup = {home: ts[0], away: ts[1]};
-                console.log(matchup);
 
                 matchup.home.won = 0;
                 matchup.away.won = 0;

--- a/js/core/season.js
+++ b/js/core/season.js
@@ -356,7 +356,7 @@ define(["dao", "globals", "core/player", "core/team", "lib/bluebird", "lib/under
      * @return {Array.<Array.<number>>} All the season's games. Each element in the array is an array of the home team ID and the away team ID, respectively.
      */
     function newScheduleDefault(teams) {
-        var cid, dids, game, games, good, i, ii, iters, j, jj, k, matchup, matchups, n, newMatchup, t, teams, tids, tidsByConf, tryNum;
+        var cid, dids, game, games, good, i, ii, iters, j, jj, k, matchup, matchups, n, newMatchup, t, tids, tidsByConf, tryNum;
 
         tids = [];  // tid_home, tid_away
 
@@ -597,7 +597,7 @@ define(["dao", "globals", "core/player", "core/team", "lib/bluebird", "lib/under
                 }
             }
         }).then(function () {
-            var i, key, matchup, team1, team2, tidsWon, sorter, sortBy, ts;
+            var i, key, matchup, sortBy, sorter, team1, team2, tidsWon, ts;
 
             // Now playoffSeries, rnd, series, and tids are set
 

--- a/js/core/team.js
+++ b/js/core/team.js
@@ -557,13 +557,19 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
 
             cond = checkSort(options.sortBy, field);
             if (cond) {
-                opt[type].indexOf(field) > -1 || opt[type].push(field); // add when not present
+                if (opt[type].indexOf(field) > -1) {
+                    opt[type].push(field); // add when not present
+                }
                 _.each(addFields, function (f) {
                     if (_.isArray(f)) {
                         opt[f[1]] = opt[f[1]] || [];
-                        opt[f[1]].indexOf(f[0]) > -1 || opt[f[1]].push(f[0]);
+                        if (opt[f[1]].indexOf(f[0]) > -1) {
+                            opt[f[1]].push(f[0]);
+                        }
                     } else {
-                        opt[type].indexOf(f) > -1 || opt[type].push(f);
+                        if (opt[type].indexOf(f) > -1) {
+                            opt[type].push(f);
+                        }
                     }
                 });
             }
@@ -573,7 +579,7 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
             assureSort('winp', null, ['won', 'lost']);
             assureSort('drank', null, [
                 ["dwinp", "sortBy"],
-                ["tid",  "attrs"]
+                ["tid", "attrs"]
             ]);
             assureSort('dwinp', null, ['wonDiv', 'lostDiv', ['did', 'attrs']]);
             assureSort('cwinp', null, ['wonConf', 'lostConf']);

--- a/js/core/team.js
+++ b/js/core/team.js
@@ -805,7 +805,7 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                     teams.map(function(t) {t.drank = 0;});
                     teams[0].drank = 1;
                 }
-            }
+            };
 
             /**
              *
@@ -815,13 +815,11 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                 ft = _.pluck(_.filter(fts, function(x) {return x.cid === t.cid;}), 'winp');
                 ft = ft.sort(function(a, b) { return b - a;});
                 if (t.drank && t.winp < ft[3]) {
-                    console.log(ft);
                     t.winpp = (ft[2] + ft[3])/2.0;
-                    console.log('fakewinp', t.region, t.winpp, t.winp)
                 } else {
                     t.winpp = t.winp;
                 }
-            }
+            };
 
             if (Array.isArray(options.sortBy)) {
                 // Sort by multiple properties

--- a/js/core/team.js
+++ b/js/core/team.js
@@ -845,17 +845,35 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
              * ranked team in the conference.
              */
             fakeWinp = function (t, fts) {
-                var ft;
-                ft = _.pluck(_.filter(fts, function (x) {
+                var breakTie, ft;
+
+                breakTie = function(a, b) {
+                    var ftmp = [a, b];
+                    ftmp = ftmp.sort(helpers.multiSort('cwinp', 'ocwinp', 'diff'));
+                    for (i = 0; i < fts.length; i++) {
+                        if (ftmp[0].tid === fts[i].tid) {
+                            fts[i].winpp = fts[i].winp + 0.0000000001;
+                        }
+
+                        if (ftmp[1].tid === fts[i].tid) {
+                            fts[i].winpp = fts[i].winp - 0.0000000001;
+                        }
+                    }
+                };
+
+                ft = _.filter(fts, function (x) {
                     return x.cid === t.cid;
-                }), 'winp');
-                ft = ft.sort(function (a, b) {
-                    return b - a;
                 });
-                if (t.drank && t.winp < ft[3]) {
-                    t.winpp = (ft[2] + ft[3]) / 2.0;
+                ft = ft.sort(function (a, b) {
+                    return b.winp - a.winp;
+                });
+                if (t.drank && t.winp < ft[3].winp) {
+                    t.winpp = (ft[2].winp + ft[3].winp) / 2.0;
+                    if (ft[2].winp === ft[3].winp) {
+                        breakTie(ft[2], ft[3]);
+                    }
                 } else {
-                    t.winpp = t.winp;
+                    t.winpp = t.winpp || t.winp;
                 }
             };
 

--- a/js/core/team.js
+++ b/js/core/team.js
@@ -557,17 +557,17 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
 
             cond = checkSort(options.sortBy, field);
             if (cond) {
-                if (opt[type].indexOf(field) > -1) {
+                if (opt[type].indexOf(field) < 0) {
                     opt[type].push(field); // add when not present
                 }
                 _.each(addFields, function (f) {
                     if (_.isArray(f)) {
                         opt[f[1]] = opt[f[1]] || [];
-                        if (opt[f[1]].indexOf(f[0]) > -1) {
+                        if (opt[f[1]].indexOf(f[0]) < 0) {
                             opt[f[1]].push(f[0]);
                         }
                     } else {
-                        if (opt[type].indexOf(f) > -1) {
+                        if (opt[type].indexOf(f) < 0) {
                             opt[type].push(f);
                         }
                     }

--- a/js/core/team.js
+++ b/js/core/team.js
@@ -569,14 +569,16 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
             }
         };
 
-        assureSort('winp', null, ['won', 'lost']);
-        assureSort('drank', null, [
-            ["dwinp", "sortBy"]
-        ]);
-        assureSort('dwinp', null, ['wonDiv', 'lostDiv', ['did', 'attrs']]);
-        assureSort('cwinp', null, ['wonConf', 'lostConf']);
-        assureSort('ocwinp', null, ['won', 'lost', 'wonConf', 'lostConf']);
-        assureSort('diff', 'stats', ['pts', 'oppPts']);
+        if (options.sortBy.length > 0) {
+            assureSort('winp', null, ['won', 'lost']);
+            assureSort('drank', null, [
+                ["dwinp", "sortBy"]
+            ]);
+            assureSort('dwinp', null, ['wonDiv', 'lostDiv', ['did', 'attrs']]);
+            assureSort('cwinp', null, ['wonConf', 'lostConf']);
+            assureSort('ocwinp', null, ['won', 'lost', 'wonConf', 'lostConf']);
+            assureSort('diff', 'stats', ['pts', 'oppPts']);
+        }
 
         // Copys/filters the attributes listed in options.attrs from p to fp.
         filterAttrs = function (ft, t, options) {

--- a/js/core/team.js
+++ b/js/core/team.js
@@ -823,8 +823,8 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                     return x.did === did;
                 });
                 s = ['winp', 'dwinp', 'cwinp', 'ocwinp', 'diff'];
-                sf = new helpers.MultiSort(s);
-                ft = ft.sort(sf.sortF);
+                sf = helpers.multiSort(s);
+                ft = ft.sort(sf);
                 for (i = 0; i < fts.length; i++) {
                     if (ft[0].tid === fts[i].tid) {
                         fts[i].drank = 1;
@@ -874,8 +874,8 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                         sortBy.splice(sortBy.indexOf('winp'), 1, 'winpp');
                     }
                 }
-                sorter = new helpers.MultiSort(sortBy);
-                fts.sort(sorter.sortF);
+                sorter = helpers.multiSort(sortBy);
+                fts.sort(sorter);
             } else if (options.sortBy === "winp") {
                 // Sort by winning percentage, descending
                 fts.sort(function (a, b) {

--- a/js/core/team.js
+++ b/js/core/team.js
@@ -860,7 +860,6 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                 divLead.push(below4.splice(0, 1)[0]);
                 divLead.sort(helpers.multiSort(s));
 
-                console.log(divLead, below4, ft, fts);
                 divLead = _.pluck(divLead, 'tid');
                 below4 = _.pluck(below4, 'tid');
 

--- a/js/core/team.js
+++ b/js/core/team.js
@@ -786,7 +786,11 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
             }
 
             /**
-             * Return true if team is rank 1 in division.
+             * Set the drank attribute of the team object.
+             * The ff. values are set for drank
+             * 1 = if team is division leader
+             * 1/(1 x tied_teams) = if there are teams in the division tied for the lead
+             * 0 = if team is not the division leader.
              */
             getDrank = function(t) {
                 var tmax, ft, count;
@@ -796,6 +800,9 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                 t.drank = Number(t.winp === tmax)/(count[tmax]);
             };
 
+            /**
+             * Break ties to determine the division winner.
+             */
             breakDivTie = function(teams) {
                 if (teams.length !== 0 ) {
                     var sortBy, s;
@@ -808,7 +815,9 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
             };
 
             /**
-             *
+             * Assure that the division leaders are in the top 4. Set a fake
+             * winpp attribute that is the average of the 3rd and 4th highest
+             * ranked team in the conference.
              */
             fakeWinp = function(t) {
                 var ft;
@@ -824,6 +833,12 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
             if (Array.isArray(options.sortBy)) {
                 // Sort by multiple properties
                 sortBy = options.sortBy.slice();
+
+                /**
+                 * If sorting by division rank (drank), the division leaders are
+                 * assured of a top 4 seeding. Sort using a fake winpp field
+                 * instead of winp.
+                 */
                 if (sortBy.indexOf('drank') > -1) {
                     if (sortBy.indexOf('winp') > -1) {
                         sortBy.splice(sortBy.indexOf('winp'), 1);

--- a/js/core/team.js
+++ b/js/core/team.js
@@ -550,29 +550,30 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
          * Assure needed fields are available for sorting.
          */
         assureSort = function (field, type, addFields) {
-            var cond;
+            var cond, opt;
+            opt = options;
             type = type || 'seasonAttrs';
             addFields = addFields || [];
 
-            _.each(addFields, function (f) {
-                if (_.isArray(f)) {
-                    options[f[1]] = options[f[1]] || [];
-                    options[f[1]].push(f[0]);
-                } else {
-                    options[type].push(f);
-                }
-            });
-
             cond = checkSort(options.sortBy, field);
             if (cond) {
-                options[type].push(field);
+                opt[type].indexOf(field) > -1 || opt[type].push(field); // add when not present
+                _.each(addFields, function (f) {
+                    if (_.isArray(f)) {
+                        opt[f[1]] = opt[f[1]] || [];
+                        opt[f[1]].indexOf(f[0]) > -1 || opt[f[1]].push(f[0]);
+                    } else {
+                        opt[type].indexOf(f) > -1 || opt[type].push(f);
+                    }
+                });
             }
         };
 
         if (options.sortBy.length > 0) {
             assureSort('winp', null, ['won', 'lost']);
             assureSort('drank', null, [
-                ["dwinp", "sortBy"]
+                ["dwinp", "sortBy"],
+                ["tid",  "attrs"]
             ]);
             assureSort('dwinp', null, ['wonDiv', 'lostDiv', ['did', 'attrs']]);
             assureSort('cwinp', null, ['wonConf', 'lostConf']);

--- a/js/core/team.js
+++ b/js/core/team.js
@@ -44,9 +44,9 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
             lostConf: 0,
             lastTen: [],
             streak: 0,
-            playoffRoundsWon: -1,  // -1: didn't make playoffs. 0: lost in first round. ... 4: won championship
+            playoffRoundsWon: -1, // -1: didn't make playoffs. 0: lost in first round. ... 4: won championship
             hype: Math.random(),
-            pop: 0,  // Needs to be set somewhere!
+            pop: 0, // Needs to be set somewhere!
             tvContract: {
                 amount: 0,
                 exp: 0
@@ -112,7 +112,7 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
 
         if (s >= 0) {
             // New season, carrying over some values from the previous season
-            newSeason.pop = t.seasons[s].pop * random.uniform(0.98, 1.02);  // Mean population should stay constant, otherwise the economics change too much
+            newSeason.pop = t.seasons[s].pop * random.uniform(0.98, 1.02); // Mean population should stay constant, otherwise the economics change too much
             newSeason.hype = t.seasons[s].hype;
             newSeason.cash = t.seasons[s].cash;
             newSeason.tvContract = t.seasons[s].tvContract;
@@ -256,12 +256,14 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
         numFC = 0;
         numC = 0;
         for (i = 0; i < positions.length; i++) {
-            if (starters.length === 5 || (numG >= 2 && numFC >= 2)) { break; }
+            if (starters.length === 5 || (numG >= 2 && numFC >= 2)) {
+                break;
+            }
 
             // Make sure we can get 2 G and 2 F/C
             if ((5 - starters.length > ((2 - numG) > 0 ? (2 - numG) : 0) + ((2 - numFC) > 0 ? (2 - numFC) : 0)) ||
-                    (numG < 2 && positions[i].indexOf('G') >= 0) ||
-                    (numFC < 2 && (positions[i].indexOf('F') >= 0 || (positions[i] === 'C' && numC === 0)))) {
+                (numG < 2 && positions[i].indexOf('G') >= 0) ||
+                (numFC < 2 && (positions[i].indexOf('F') >= 0 || (positions[i] === 'C' && numC === 0)))) {
                 starters.push(i);
                 numG += positions[i].indexOf('G') >= 0 ? 1 : 0;
                 numFC += (positions[i].indexOf('F') >= 0 || positions[i] === 'C') ? 1 : 0;
@@ -271,9 +273,15 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
 
         // Fill in after meeting requirements, but still not too many Cs!
         for (i = 0; i < positions.length; i++) {
-            if (starters.length === 5) { break; }
-            if (starters.indexOf(i) >= 0) { continue; }
-            if (numC >= 1 && positions[i] === 'c') { continue; }
+            if (starters.length === 5) {
+                break;
+            }
+            if (starters.indexOf(i) >= 0) {
+                continue;
+            }
+            if (numC >= 1 && positions[i] === 'c') {
+                continue;
+            }
 
             starters.push(i);
             numC += positions[i] === 'C' ? 1 : 0;
@@ -312,9 +320,13 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
             });
             // Fuzz only for user's team
             if (tid === g.userTid) {
-                players.sort(function (a, b) { return b.valueNoPotFuzz - a.valueNoPotFuzz; });
+                players.sort(function (a, b) {
+                    return b.valueNoPotFuzz - a.valueNoPotFuzz;
+                });
             } else {
-                players.sort(function (a, b) { return b.valueNoPot - a.valueNoPot; });
+                players.sort(function (a, b) {
+                    return b.valueNoPot - a.valueNoPot;
+                });
             }
 
             // Shuffle array so that position conditions are met - 2 G and 2 F/C in starting lineup, at most one pure C
@@ -360,15 +372,15 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
     }
 
     /**
-    * Gets all the contracts a team owes.
-    *
-    * This includes contracts for players who have been released but are still owed money.
-    *
-    * @memberOf core.team
-    * @param {IDBTransaction|null} tx An IndexedDB transaction on players and releasedPlayers; if null is passed, then a new transaction will be used.
-    * @param {number} tid Team ID.
-    * @returns {Promise.Array} Array of objects containing contract information.
-    */
+     * Gets all the contracts a team owes.
+     *
+     * This includes contracts for players who have been released but are still owed money.
+     *
+     * @memberOf core.team
+     * @param {IDBTransaction|null} tx An IndexedDB transaction on players and releasedPlayers; if null is passed, then a new transaction will be used.
+     * @param {number} tid Team ID.
+     * @returns {Promise.Array} Array of objects containing contract information.
+     */
     function getContracts(tx, tid) {
         var contracts;
 
@@ -457,7 +469,7 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
 
             payroll = 0;
             for (i = 0; i < contracts.length; i++) {
-                payroll += contracts[i].amount;  // No need to check exp, since anyone without a contract for the current season will not have an entry
+                payroll += contracts[i].amount; // No need to check exp, since anyone without a contract for the current season will not have an entry
             }
 
             return [payroll, contracts];
@@ -505,9 +517,11 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
      * @return {Promise.(Object|Array.<Object>)} Filtered team object or array of filtered team objects, depending on the inputs.
      */
     function filter(options) {
-        var filterAttrs, filterSeasonAttrs, filterStats, filterStatsPartial, checkSort, assureSort;
+        var assureSort, checkSort, filterAttrs, filterSeasonAttrs, filterStats, filterStatsPartial;
 
-        if (arguments[1] !== undefined) { throw new Error("No cb should be here"); }
+        if (arguments[1] !== undefined) {
+            throw new Error("No cb should be here");
+        }
 
         options = options !== undefined ? options : {};
         options.season = options.season !== undefined ? options.season : null;
@@ -523,7 +537,7 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
         /**
          * check if field is in sortBy
          */
-        checkSort = function(sortBy, field) {
+        checkSort = function (sortBy, field) {
             var cond, rev;
             rev = '-' + field;
             cond = Array.isArray(sortBy) && (sortBy.indexOf(field) > -1 || sortBy.indexOf(rev) > -1);
@@ -535,16 +549,16 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
         /**
          * Assure needed fields are available for sorting.
          */
-        assureSort = function(field, type, addFields) {
+        assureSort = function (field, type, addFields) {
+            var cond;
             type = type || 'seasonAttrs';
             addFields = addFields || [];
-            var cond;
 
-            _.each(addFields, function(f) {
+            _.each(addFields, function (f) {
                 if (_.isArray(f)) {
                     options[f[1]] = options[f[1]] || [];
                     options[f[1]].push(f[0]);
-                } else{
+                } else {
                     options[type].push(f);
                 }
             });
@@ -553,11 +567,12 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
             if (cond) {
                 options[type].push(field);
             }
-
         };
 
         assureSort('winp', null, ['won', 'lost']);
-        assureSort('drank',  null, [["dwinp","sortBy"]])
+        assureSort('drank', null, [
+            ["dwinp", "sortBy"]
+        ]);
         assureSort('dwinp', null, ['wonDiv', 'lostDiv', ['did', 'attrs']]);
         assureSort('cwinp', null, ['wonConf', 'lostConf']);
         assureSort('ocwinp', null, ['won', 'lost', 'wonConf', 'lostConf']);
@@ -571,7 +586,7 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                 if (options.attrs[j] === "budget") {
                     ft.budget = helpers.deepCopy(t.budget);
                     _.each(ft.budget, function (value, key) {
-                        if (key !== "ticketPrice") {  // ticketPrice is the only thing in dollars always
+                        if (key !== "ticketPrice") { // ticketPrice is the only thing in dollars always
                             value.amount /= 1000;
                         }
                     });
@@ -579,12 +594,11 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                     ft[options.attrs[j]] = t[options.attrs[j]];
                 }
             }
-
         };
 
         // Copys/filters the seasonal attributes listed in options.seasonAttrs from p to fp.
         filterSeasonAttrs = function (ft, t, options) {
-            var j, lastTenLost, lastTenWon, tsa;
+            var j, lastTenLost, lastTenWon, othLost, othWon, tsa;
 
             if (options.seasonAttrs.length > 0) {
                 for (j = 0; j < t.seasons.length; j++) {
@@ -600,8 +614,12 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                 }
 
                 // Revenue and expenses calculation
-                tsa.revenue = _.reduce(tsa.revenues, function (memo, revenue) { return memo + revenue.amount; }, 0);
-                tsa.expense = _.reduce(tsa.expenses, function (memo, expense) { return memo + expense.amount; }, 0);
+                tsa.revenue = _.reduce(tsa.revenues, function (memo, revenue) {
+                    return memo + revenue.amount;
+                }, 0);
+                tsa.expense = _.reduce(tsa.expenses, function (memo, expense) {
+                    return memo + expense.amount;
+                }, 0);
 
                 for (j = 0; j < options.seasonAttrs.length; j++) {
                     if (options.seasonAttrs[j] === "winp") {
@@ -609,46 +627,49 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                         if (tsa.won + tsa.lost > 0) {
                             ft.winp = tsa.won / (tsa.won + tsa.lost);
                         }
-                    } else if(options.seasonAttrs[j] === 'dwinp') {
+                    } else if (options.seasonAttrs[j] === 'dwinp') {
                         ft.dwinp = 0;
                         if (tsa.wonDiv + tsa.lostDiv > 0) {
-                            ft.dwinp = tsa.wonDiv /  (tsa.wonDiv + tsa.lostDiv);
+                            ft.dwinp = tsa.wonDiv / (tsa.wonDiv + tsa.lostDiv);
                         }
-                    } else if(options.seasonAttrs[j] === 'cwinp') {
+                    } else if (options.seasonAttrs[j] === 'cwinp') {
                         ft.cwinp = 0;
                         if (tsa.wonConf + tsa.lostConf > 0) {
                             ft.cwinp = tsa.wonConf / (tsa.wonConf + tsa.lostConf);
                         }
-                    } else if(options.seasonAttrs[j] === 'ocwinp') {
+                    } else if (options.seasonAttrs[j] === 'ocwinp') {
                         ft.ocwinp = 0;
                         if (tsa.won + tsa.lost > 0) {
-                            var othWon, othLost;
                             othWon = Math.max(tsa.won - tsa.wonConf, 0);
                             othLost = Math.max(tsa.lost - tsa.lostConf, 0);
                             ft.ocwinp = othWon / (othWon + othLost);
                         }
                     } else if (options.seasonAttrs[j] === "att") {
                         ft.att = 0;
-                        if (!tsa.hasOwnProperty("gpHome")) { tsa.gpHome = Math.round(tsa.gp / 2); } // See also game.js and teamFinances.js
+                        if (!tsa.hasOwnProperty("gpHome")) {
+                            tsa.gpHome = Math.round(tsa.gp / 2);
+                        } // See also game.js and teamFinances.js
                         if (tsa.gpHome > 0) {
                             ft.att = tsa.att / tsa.gpHome;
                         }
                     } else if (options.seasonAttrs[j] === "cash") {
-                        ft.cash = tsa.cash / 1000;  // [millions of dollars]
+                        ft.cash = tsa.cash / 1000; // [millions of dollars]
                     } else if (options.seasonAttrs[j] === "revenue") {
-                        ft.revenue = tsa.revenue / 1000;  // [millions of dollars]
+                        ft.revenue = tsa.revenue / 1000; // [millions of dollars]
                     } else if (options.seasonAttrs[j] === "profit") {
-                        ft.profit = (tsa.revenue - tsa.expense) / 1000;  // [millions of dollars]
+                        ft.profit = (tsa.revenue - tsa.expense) / 1000; // [millions of dollars]
                     } else if (options.seasonAttrs[j] === "salaryPaid") {
-                        ft.salaryPaid = tsa.expenses.salary.amount / 1000;  // [millions of dollars]
+                        ft.salaryPaid = tsa.expenses.salary.amount / 1000; // [millions of dollars]
                     } else if (options.seasonAttrs[j] === "payroll") {
                         // Handled later
                         ft.payroll = null;
                     } else if (options.seasonAttrs[j] === "lastTen") {
-                        lastTenWon = _.reduce(tsa.lastTen, function (memo, num) { return memo + num; }, 0);
+                        lastTenWon = _.reduce(tsa.lastTen, function (memo, num) {
+                            return memo + num;
+                        }, 0);
                         lastTenLost = tsa.lastTen.length - lastTenWon;
                         ft.lastTen = lastTenWon + "-" + lastTenLost;
-                    } else if (options.seasonAttrs[j] === "streak") {  // For standings
+                    } else if (options.seasonAttrs[j] === "streak") { // For standings
                         if (tsa.streak === 0) {
                             ft.streak = "None";
                         } else if (tsa.streak > 0) {
@@ -768,8 +789,11 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
             }
         };
 
-        return dao.teams.getAll({ot: options.ot, key: options.tid}).then(function (t) {
-            var ft, fts, i, returnOneTeam, savePayroll, sortBy, getDrank, fakeWinp, sorter;
+        return dao.teams.getAll({
+            ot: options.ot,
+            key: options.tid
+        }).then(function (t) {
+            var fakeWinp, ft, fts, getDrank, i, returnOneTeam, savePayroll, sortBy, sorter;
 
             // t will be an array of g.numTeams teams (if options.tid is null) or an array of 1 team. If 1, then we want to return just that team object at the end, not an array of 1 team.
             returnOneTeam = false;
@@ -791,13 +815,15 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
              * Set the drank attribute of the team object.
              * 1 = if team is division leader
              */
-            getDrank = function(did, fts) {
-                var ft, s, sf;
-                ft = fts.filter(function(x) {return x.did === did;});
-                s = ['winp', 'dwinp', 'cwinp', 'ocwinp', 'diff']
+            getDrank = function (did, fts) {
+                var ft, i, s, sf;
+                ft = fts.filter(function (x) {
+                    return x.did === did;
+                });
+                s = ['winp', 'dwinp', 'cwinp', 'ocwinp', 'diff'];
                 sf = new helpers.MultiSort(s);
                 ft = ft.sort(sf.sortF);
-                for (var i = 0; i < fts.length; i++) {
+                for (i = 0; i < fts.length; i++) {
                     if (ft[0].tid === fts[i].tid) {
                         fts[i].drank = 1;
                     }
@@ -809,12 +835,16 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
              * winpp attribute that is the average of the 3rd and 4th highest
              * ranked team in the conference.
              */
-            fakeWinp = function(t, fts) {
+            fakeWinp = function (t, fts) {
                 var ft;
-                ft = _.pluck(_.filter(fts, function(x) {return x.cid === t.cid;}), 'winp');
-                ft = ft.sort(function(a, b) { return b - a;});
+                ft = _.pluck(_.filter(fts, function (x) {
+                    return x.cid === t.cid;
+                }), 'winp');
+                ft = ft.sort(function (a, b) {
+                    return b - a;
+                });
                 if (t.drank && t.winp < ft[3]) {
-                    t.winpp = (ft[2] + ft[3])/2.0;
+                    t.winpp = (ft[2] + ft[3]) / 2.0;
                 } else {
                     t.winpp = t.winp;
                 }
@@ -830,8 +860,10 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                  * instead of winp.
                  */
                 if (sortBy.indexOf('drank') > -1) {
-                    _.each(_.range(0, 6), function(did) { getDrank(did, fts); });
-                    fts.map(function(t) {
+                    _.each(_.range(0, 6), function (did) {
+                        getDrank(did, fts);
+                    });
+                    fts.map(function (t) {
                         t.drank = t.drank || 0;
                         fakeWinp(t, fts);
                         // set winpp value and init drank for non leaders.
@@ -844,7 +876,9 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                 fts.sort(sorter.sortF);
             } else if (options.sortBy === "winp") {
                 // Sort by winning percentage, descending
-                fts.sort(function (a, b) { return b.winp - a.winp; });
+                fts.sort(function (a, b) {
+                    return b.winp - a.winp;
+                });
             }
 
             // If payroll for the current season was requested, find the current payroll for each team. Otherwise, don't.
@@ -948,7 +982,9 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
             // For each draft pick, estimate its value based on the recent performance of the team
             if (dpidsAdd.length > 0 || dpidsRemove.length > 0) {
                 // Estimate the order of the picks by team
-                dao.teams.getAll({ot: tx}).then(function (teams) {
+                dao.teams.getAll({
+                    ot: tx
+                }).then(function (teams) {
                     var estPicks, estValues, gp, i, rCurrent, rLast, rookieSalaries, s, sorted, t, withEstValues, wps;
 
                     // This part needs to be run every time so that gpAvg is available
@@ -992,8 +1028,12 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                     }
 
                     // Get rank order of wps http://stackoverflow.com/a/14834599/786644
-                    sorted = wps.slice().sort(function (a, b) { return a - b; });
-                    estPicks = wps.slice().map(function (v) { return sorted.indexOf(v) + 1; }); // For each team, what is their estimated draft position?
+                    sorted = wps.slice().sort(function (a, b) {
+                        return a - b;
+                    });
+                    estPicks = wps.slice().map(function (v) {
+                        return sorted.indexOf(v) + 1;
+                    }); // For each team, what is their estimated draft position?
 
                     rookieSalaries = require("core/draft").getRookieSalaries();
 
@@ -1002,7 +1042,10 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                         var i;
 
                         for (i = 0; i < dpidsAdd.length; i++) {
-                            dao.draftPicks.get({ot: tx, key: dpidsAdd[i]}).then(function (dp) {
+                            dao.draftPicks.get({
+                                ot: tx,
+                                key: dpidsAdd[i]
+                            }).then(function (dp) {
                                 var estPick, seasons, value;
 
                                 estPick = estPicks[dp.originalTid];
@@ -1030,7 +1073,10 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                                         amount: rookieSalaries[estPick - 1 + g.numTeams * (dp.round - 1)],
                                         exp: dp.season + 2 + (2 - dp.round) // 3 for first round, 2 for second
                                     },
-                                    injury: {type: "Healthy", gamesRemaining: 0},
+                                    injury: {
+                                        type: "Healthy",
+                                        gamesRemaining: 0
+                                    },
                                     age: 19,
                                     draftPick: true
                                 });
@@ -1038,7 +1084,10 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                         }
 
                         for (i = 0; i < dpidsRemove.length; i++) {
-                            dao.draftPicks.get({ot: tx, key: dpidsRemove[i]}).then(function (dp) {
+                            dao.draftPicks.get({
+                                ot: tx,
+                                key: dpidsRemove[i]
+                            }).then(function (dp) {
                                 var estPick, fudgeFactor, seasons, value;
 
                                 estPick = estPicks[dp.originalTid];
@@ -1073,7 +1122,10 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                                         amount: rookieSalaries[estPick - 1 + g.numTeams * (dp.round - 1)] / 1000,
                                         exp: dp.season + 2 + (2 - dp.round) // 3 for first round, 2 for second
                                     },
-                                    injury: {type: "Healthy", gamesRemaining: 0},
+                                    injury: {
+                                        type: "Healthy",
+                                        gamesRemaining: 0
+                                    },
                                     age: 19,
                                     draftPick: true
                                 });
@@ -1123,35 +1175,35 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
 
             gpAvg = helpers.bound(gpAvg, 0, 82);
 
-/*            // Handle situations where the team goes over the roster size limit
-            if (roster.length + remove.length > 15) {
-                // Already over roster limit, so don't worry unless this trade actually makes it worse
-                needToDrop = (roster.length + add.length) - (roster.length + remove.length);
-            } else {
-                needToDrop = (roster.length + add.length) - 15;
-            }
-            roster.sort(function (a, b) { return a.value - b.value; }); // Sort by value, ascending
-            add.sort(function (a, b) { return a.value - b.value; }); // Sort by value, ascending
-            while (needToDrop > 0) {
-                // Find lowest value player, from roster or add. Delete him and move his salary to the second lowest value player.
-                if (roster[0].value < add[0].value) {
-                    if (roster[1].value < add[0].value) {
-                        roster[1].contract.amount += roster[0].contract.amount;
-                    } else {
-                        add[0].contract.amount += roster[0].contract.amount;
-                    }
-                    roster.shift(); // Remove from value calculation
-                } else {
-                    if (add.length > 1 && add[1].value < roster[0].value) {
-                        add[1].contract.amount += add[0].contract.amount;
-                    } else {
-                        roster[0].contract.amount += add[0].contract.amount;
-                    }
-                    add.shift(); // Remove from value calculation
-                }
+            /*            // Handle situations where the team goes over the roster size limit
+                        if (roster.length + remove.length > 15) {
+                            // Already over roster limit, so don't worry unless this trade actually makes it worse
+                            needToDrop = (roster.length + add.length) - (roster.length + remove.length);
+                        } else {
+                            needToDrop = (roster.length + add.length) - 15;
+                        }
+                        roster.sort(function (a, b) { return a.value - b.value; }); // Sort by value, ascending
+                        add.sort(function (a, b) { return a.value - b.value; }); // Sort by value, ascending
+                        while (needToDrop > 0) {
+                            // Find lowest value player, from roster or add. Delete him and move his salary to the second lowest value player.
+                            if (roster[0].value < add[0].value) {
+                                if (roster[1].value < add[0].value) {
+                                    roster[1].contract.amount += roster[0].contract.amount;
+                                } else {
+                                    add[0].contract.amount += roster[0].contract.amount;
+                                }
+                                roster.shift(); // Remove from value calculation
+                            } else {
+                                if (add.length > 1 && add[1].value < roster[0].value) {
+                                    add[1].contract.amount += add[0].contract.amount;
+                                } else {
+                                    roster[0].contract.amount += add[0].contract.amount;
+                                }
+                                add.shift(); // Remove from value calculation
+                            }
 
-                needToDrop -= 1;
-            }*/
+                            needToDrop -= 1;
+                        }*/
 
             // This roughly corresponds with core.gameSim.updateSynergy
             skillsNeeded = {
@@ -1179,7 +1231,9 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                 rosterSkillsCount = _.countBy(rosterSkills);
 
                 // Sort test by value, so that the highest value players get bonuses applied first
-                test.sort(function (a, b) { return b.value - a.value; });
+                test.sort(function (a, b) {
+                    return b.value - a.value;
+                });
 
                 for (i = 0; i < test.length; i++) {
                     if (test.value >= 45) {
@@ -1282,7 +1336,7 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
                     if (playerValue < 0) {
                         playerValue = 0;
                     }
-//console.log([playerValue, contractValue]);
+                    //console.log([playerValue, contractValue]);
 
                     value = playerValue + 0.5 * contractValue;
 
@@ -1329,11 +1383,11 @@ define(["dao", "globals", "core/player", "lib/bluebird", "lib/underscore", "util
             salaryRemoved = sumContracts(remove) - sumContracts(add);
 
             dv = sumValues(add, true) - sumValues(remove) + contractsFactor * salaryRemoved;
-/*console.log("Added players/picks: " + sumValues(add, true));
-console.log("Removed players/picks: " + (-sumValues(remove)));
-console.log("Added contract quality: -" + contractExcessFactor + " * " + sumContractExcess(add));
-console.log("Removed contract quality: -" + contractExcessFactor + " * " + sumContractExcess(remove));
-console.log("Total contract amount: " + contractsFactor + " * " + salaryRemoved);*/
+            /*console.log("Added players/picks: " + sumValues(add, true));
+            console.log("Removed players/picks: " + (-sumValues(remove)));
+            console.log("Added contract quality: -" + contractExcessFactor + " * " + sumContractExcess(add));
+            console.log("Removed contract quality: -" + contractExcessFactor + " * " + sumContractExcess(remove));
+            console.log("Total contract amount: " + contractsFactor + " * " + salaryRemoved);*/
 
             // Aversion towards losing cap space in a trade during free agency
             if (g.phase >= g.PHASE.RESIGN_PLAYERS || g.phase <= g.PHASE.FREE_AGENCY) {
@@ -1342,7 +1396,7 @@ console.log("Total contract amount: " + contractsFactor + " * " + salaryRemoved)
                     salaryAddedThisSeason = sumContracts(add, true) - sumContracts(remove, true);
                     // Only care if cap space is being used
                     if (salaryAddedThisSeason > 0) {
-//console.log("Free agency penalty: -" + (0.2 + 0.8 * g.daysLeft / 30) * salaryAddedThisSeason);
+                        //console.log("Free agency penalty: -" + (0.2 + 0.8 * g.daysLeft / 30) * salaryAddedThisSeason);
                         dv -= (0.2 + 0.8 * g.daysLeft / 30) * salaryAddedThisSeason; // 0.2 to 1 times the amount, depending on stage of free agency
                     }
                 }
@@ -1355,10 +1409,10 @@ console.log("Total contract amount: " + contractsFactor + " * " + salaryRemoved)
             }
 
             return dv;
-/*console.log('---');
-console.log([sumValues(add), sumContracts(add)]);
-console.log([sumValues(remove), sumContracts(remove)]);
-console.log(dv);*/
+            /*console.log('---');
+            console.log([sumValues(add), sumContracts(add)]);
+            console.log([sumValues(remove), sumContracts(remove)]);
+            console.log(dv);*/
         });
     }
 
@@ -1459,7 +1513,11 @@ console.log(dv);*/
         var checkRosterSize, minFreeAgents, tx, userTeamSizeError;
 
         checkRosterSize = function (tid) {
-            return dao.players.getAll({ot: tx, index: "tid", key: tid}).then(function (players) {
+            return dao.players.getAll({
+                ot: tx,
+                index: "tid",
+                key: tid
+            }).then(function (players) {
                 var i, numPlayersOnRoster, p, promises;
 
                 numPlayersOnRoster = players.length;
@@ -1473,7 +1531,9 @@ console.log(dv);*/
                         userTeamSizeError += 'more than the maximum number of players (15). You must remove players (by <a href="' + helpers.leagueUrl(["roster"]) + '">releasing them from your roster</a> or through <a href="' + helpers.leagueUrl(["trade"]) + '">trades</a>) before continuing.';
                     } else {
                         // Automatically drop lowest value players until we reach 15
-                        players.sort(function (a, b) { return a.value - b.value; }); // Lowest first
+                        players.sort(function (a, b) {
+                            return a.value - b.value;
+                        }); // Lowest first
                         promises = [];
                         for (i = 0; i < (numPlayersOnRoster - 15); i++) {
                             promises.push(player.release(tx, players[i], false));
@@ -1507,7 +1567,10 @@ console.log(dv);*/
                                 tids: [p.tid]
                             });
 
-                            promises.push(dao.players.put({ot: tx, value: p}));
+                            promises.push(dao.players.put({
+                                ot: tx,
+                                value: p
+                            }));
 
                             numPlayersOnRoster += 1;
                         }
@@ -1527,7 +1590,11 @@ console.log(dv);*/
 
         userTeamSizeError = null;
 
-        return dao.players.getAll({ot: tx, index: "tid", key: g.PLAYER.FREE_AGENT}).then(function (players) {
+        return dao.players.getAll({
+            ot: tx,
+            index: "tid",
+            key: g.PLAYER.FREE_AGENT
+        }).then(function (players) {
             var i, promises;
 
             // List of free agents looking for minimum contracts, sorted by value. This is used to bump teams up to the minimum roster size.
@@ -1537,7 +1604,9 @@ console.log(dv);*/
                     minFreeAgents.push(players[i]);
                 }
             }
-            minFreeAgents.sort(function (a, b) { return b.value - a.value; });
+            minFreeAgents.sort(function (a, b) {
+                return b.value - a.value;
+            });
 
             // Make sure teams are all within the roster limits
             promises = [];

--- a/js/globals.js
+++ b/js/globals.js
@@ -21,6 +21,7 @@ define(["lib/knockout"], function (ko) {
     g.minContract = 500;  // [thousands of dollars]
     g.maxContract = 20000;  // [thousands of dollars]
     g.minRosterSize = 10;
+    g.divLeaderTop4 = false;
 
     // Constants in all caps
     g.PHASE = {
@@ -176,7 +177,7 @@ define(["lib/knockout"], function (ko) {
     g.stripePublishableKey = "pk_live_Dmo7Vs6uSaoYHrFngr4lM0sa";
 
     // THIS MUST BE ACCURATE OR BAD STUFF WILL HAPPEN
-    g.notInDb = ["dbm", "dbl", "lid", "confs", "divs", "salaryCap", "minPayroll", "luxuryPayroll", "luxuryTax", "minContract", "maxContract", "minRosterSize", "PHASE", "PLAYER", "PHASE_TEXT", "gameSimWorkers", "vm", "enableLogging", "tld", "sport", "compositeWeights", "stripePublishableKey", "notInDb"];
+    g.notInDb = ["dbm", "dbl", "lid", "confs", "divs", "salaryCap", "minPayroll", "luxuryPayroll", "luxuryTax", "minContract", "maxContract", "minRosterSize", "divLeaderTop4", "PHASE", "PLAYER", "PHASE_TEXT", "gameSimWorkers", "vm", "enableLogging", "tld", "sport", "compositeWeights", "stripePublishableKey", "notInDb"];
 
     return g;
 });

--- a/js/test/app.js
+++ b/js/test/app.js
@@ -28,6 +28,8 @@ require.config({
 require(["lib/chai", "lib/IndexedDB-getAll-shim", "util/templateHelpers"], function (chai) {
     "use strict";
     var modules = ["test/core/contractNegotiation", "test/core/draft", "test/core/finances", "test/core/league", "test/core/player", "test/core/season", "test/core/team", "test/core/trade", "test/util/account", "test/util/helpers", "test/views/components", "test/views/gameLog"];
+    // test only module
+    // modules = ['test/core/season'];
 
     mocha.setup({
         ui: "bdd",

--- a/js/test/app.js
+++ b/js/test/app.js
@@ -27,6 +27,7 @@ require.config({
 
 require(["lib/chai", "lib/IndexedDB-getAll-shim", "util/templateHelpers"], function (chai) {
     "use strict";
+    var modules = ["test/core/contractNegotiation", "test/core/draft", "test/core/finances", "test/core/league", "test/core/player", "test/core/season", "test/core/team", "test/core/trade", "test/util/account", "test/util/helpers", "test/views/components", "test/views/gameLog"];
 
     mocha.setup({
         ui: "bdd",
@@ -35,7 +36,7 @@ require(["lib/chai", "lib/IndexedDB-getAll-shim", "util/templateHelpers"], funct
     });
     should = chai.should();
 
-    require(["test/core/contractNegotiation", "test/core/draft", "test/core/finances", "test/core/league", "test/core/player", "test/core/season", "test/core/team", "test/core/trade", "test/util/account", "test/util/helpers", "test/views/components", "test/views/gameLog"], function () {
+    require(modules, function () {
         startTests();
     });
 });

--- a/js/test/core/season.js
+++ b/js/test/core/season.js
@@ -115,8 +115,8 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
             })
                 .then(function() {
                     return Promise.try(function () {
-                            return $.getJSON("../../data/sample_tiebreakers.json")
-                        })
+                            return $.getJSON("../../data/sample_tiebreakers.json");
+                        });
                 })
                 .then(function (teams) {
                     tx = dao.tx(["teams", "playoffSeries"], "readwrite");
@@ -129,7 +129,7 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
                     });
                 }).then(function() {
                     done();
-                })
+                });
         });
         after(function () {
             return league.remove(g.lid);
@@ -148,7 +148,7 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
                     .then(function(series) {
                         pseries = series;
                         done();
-                    })
+                    });
             });
             it("should rank teams with the same records properly.", function() {
                 var r1 = pseries.series[0];
@@ -170,7 +170,7 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
             });
             after(function(done) {
                 var i, r1;
-                var r1 = pseries.series[0];
+                r1 = pseries.series[0];
 
                 for (i = 0; i < r1.length; i++) {
                     if (i === 3) {
@@ -182,7 +182,7 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
                 dao.playoffSeries.put({value: pseries})
                     .then(function() {
                         done();
-                    })
+                    });
             });
         });
         describe("#newSchedulePlayoffsDay", function() {
@@ -199,8 +199,8 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
                     .then(function(series) {
                         pseries = series;
                         done();
-                    })
-            })
+                    });
+            });
 
             it("should create matchups for next round with proper HCA", function() {
                 var r2 = pseries.series[1];

--- a/js/test/core/season.js
+++ b/js/test/core/season.js
@@ -107,7 +107,7 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
         });
     });
 
-    describe('playoffs tiebreakers', function() {
+    describe('core/season playoffs tiebreakers', function() {
         var tx;
         before(function(done) {
             return db.connectMeta().then(function () {
@@ -134,7 +134,7 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
         after(function () {
             return league.remove(g.lid);
         });
-        describe("create playoff matchups", function() {
+        describe("#createPlayoffMatchups", function() {
             var pseries;
             before(function(done) {
                 tx = dao.tx(["teams", "playoffSeries", "players", "playerStats", "events"], "readwrite");

--- a/js/test/core/season.js
+++ b/js/test/core/season.js
@@ -109,7 +109,7 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
 
     describe('core/season playoffs tiebreakers', function() {
         var tx;
-        before(function(done) {
+        before(function() {
             return db.connectMeta().then(function () {
                 return league.create("Test", 15, undefined, 2015, false);
             })
@@ -127,18 +127,16 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
                             return t;
                         }
                     });
-                }).then(function() {
-                    done();
-                });
+                })
         });
         after(function () {
             return league.remove(g.lid);
         });
         describe("#createPlayoffMatchups", function() {
             var pseries;
-            before(function(done) {
+            before(function() {
                 tx = dao.tx(["teams", "playoffSeries", "players", "playerStats", "events"], "readwrite");
-                season.createPlayoffMatchups(tx)
+                return season.createPlayoffMatchups(tx)
                     .then(function() {
                         return dao.playoffSeries.get({
                                 ot: tx,
@@ -147,7 +145,6 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
                     })
                     .then(function(series) {
                         pseries = series;
-                        done();
                     });
             });
             it("should rank teams with the same records properly.", function() {
@@ -197,9 +194,9 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
         });
         describe("#newSchedulePlayoffsDay", function() {
             var pseries;
-            before(function(done) {
+            before(function() {
                 tx = dao.tx(["teams", "playoffSeries", "players", "playerStats", "events", "schedule"], "readwrite");
-                season.newSchedulePlayoffsDay(tx)
+                return season.newSchedulePlayoffsDay(tx)
                     .then(function() {
                         return dao.playoffSeries.get({
                             ot: tx,
@@ -208,7 +205,6 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
                     })
                     .then(function(series) {
                         pseries = series;
-                        done();
                     });
             });
 

--- a/js/test/core/season.js
+++ b/js/test/core/season.js
@@ -166,13 +166,13 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
                     season: g.season
                 }).then(function(teams) {
                     // 13 is ranked higher than 26 when drank is considered
-                    teams[1].tid.should.equal(13);
-                    teams[2].tid.should.equal(26);
+                    teams[2].tid.should.equal(13);
+                    teams[1].tid.should.equal(26);
 
                     // 5 is div winner, should be ranked higher than 29 which
                     // has a better record.
-                    teams[5].tid.should.equal(5);
-                    teams[7].tid.should.equal(29);
+                    teams[6].tid.should.equal(5);
+                    teams[8].tid.should.equal(29);
                 });
             });
             after(function(done) {

--- a/js/test/core/season.js
+++ b/js/test/core/season.js
@@ -153,20 +153,30 @@ define(["globals", "core/season", "util/helpers", "test/helpers", "dao", "lib/jq
             it("should rank teams with the same records properly.", function() {
                 var r1 = pseries.series[0];
 
-                // 13 and 26 tied for first, 13 is 1 seed, 26 is 2 seed.
-                r1[0].home.tid.should.equal(13);
-                r1[3].home.tid.should.equal(26);
+                // 13 and 26 tied for first, 26 is 1 seed, 13 is 2 seed,
+                r1[0].home.tid.should.equal(26);
+                r1[3].home.tid.should.equal(13);
 
                 // 10 is 7, 18 is 6
                 r1[7].away.tid.should.equal(10);
                 r1[6].away.tid.should.equal(18);
             });
-            it("should give HCA advantage to teams with better records", function() {
-                var r1 = pseries.series[0];
+            it("should rank div leader in top 4 if option divLeaderTop4 is true", function() {
+                g.divLeaderTop4 = true;
+                return require('core/team').filter({
+                    attrs: ['tid'],
+                    sortBy: helpers.getPlayoffSorting(),
+                    season: g.season
+                }).then(function(teams) {
+                    // 13 is ranked higher than 26 when drank is considered
+                    teams[1].tid.should.equal(13);
+                    teams[2].tid.should.equal(26);
 
-                // 5 is div winner, 29 has better record
-                r1[1].away.tid.should.equal(5);
-                r1[1].home.tid.should.equal(29);
+                    // 5 is div winner, should be ranked higher than 29 which
+                    // has a better record.
+                    teams[5].tid.should.equal(5);
+                    teams[7].tid.should.equal(29);
+                });
             });
             after(function(done) {
                 var i, r1;

--- a/js/test/core/team.js
+++ b/js/test/core/team.js
@@ -77,6 +77,7 @@ define(["dao", "db", "globals", "core/league", "core/player", "core/team"], func
                     });
                 });
             });
+
             after(function () {
                 return league.remove(g.lid);
             });

--- a/js/test/util/helpers.js
+++ b/js/test/util/helpers.js
@@ -2,11 +2,13 @@
  * @name test.util.helpers
  * @namespace Tests for util.helpers.
  */
-define(["globals", "util/helpers"], function (g, helpers) {
+define(["globals", "util/helpers", "lib/underscore"], function (g, helpers, _) {
     "use strict";
 
     describe("util/helpers", function () {
         before(function (done) {
+            g.teamAbbrevsCache = _.pluck(helpers.getTeamsDefault(), "abbrev");
+            g.numTeams = 30;
             g.userTid = 4;
             g.startingSeason = 2007;
             g.season = 2009;

--- a/js/util/helpers.js
+++ b/js/util/helpers.js
@@ -882,6 +882,12 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
         return (arg > 0 ? "+" : "") + round(arg, d);
     }
 
+    /**
+     * Constructor for a sorter object. Use the objects sortF member as the sort
+     * function for the object list.
+     *
+     * @param {Array of String fields} sortBy sorting fields in order of application
+     */
     function MultiSort(sortBy) {
 
         sortBy = sortBy;
@@ -907,6 +913,10 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
         };
     }
 
+    /**
+     * Determine HCA advantage for this matchup. Team with better winp, cwinp,
+     * ocwinp and diff will get HCA regardless of seeding.
+     */
     function seriesHomeAway(series, teamsConf, seed1, seed2, order, cid) {
         var teams, sortBy, sorter;
         sortBy = ['winp', 'cwinp', 'ocwinp', 'diff'];

--- a/js/util/helpers.js
+++ b/js/util/helpers.js
@@ -115,7 +115,10 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
         seasons = [];
         for (season = g.startingSeason; season <= g.season; season++) {
             if (season !== ignoredSeason) {
-                seasons.push({season: season, selected: selectedSeason === season});
+                seasons.push({
+                    season: season,
+                    selected: selectedSeason === season
+                });
             }
         }
         return seasons;
@@ -178,7 +181,9 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
 
         // Add popRank
         teamsSorted = teams.slice(); // Deep copy
-        teamsSorted.sort(function (a, b) { return b.pop - a.pop; });
+        teamsSorted.sort(function (a, b) {
+            return b.pop - a.pop;
+        });
         for (i = 0; i < teams.length; i++) {
             for (j = 0; j < teamsSorted.length; j++) {
                 if (teams[i].tid === teamsSorted[j].tid) {
@@ -214,38 +219,247 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
     function getTeamsDefault() {
         var teams;
 
-        teams = [
-            {tid: 0, cid: 0, did: 2, region: "Atlanta", name: "Gold Club", abbrev: "ATL", pop: 4.3},
-            {tid: 1, cid: 0, did: 2, region: "Baltimore", name: "Crabs", abbrev: "BAL", pop: 2.2},
-            {tid: 2, cid: 0, did: 0, region: "Boston", name: "Massacre", abbrev: "BOS", pop: 4.4},
-            {tid: 3, cid: 0, did: 1, region: "Chicago", name: "Whirlwinds", abbrev: "CHI", pop: 8.8},
-            {tid: 4, cid: 0, did: 1, region: "Cincinnati", name: "Riots", abbrev: "CIN", pop: 1.6},
-            {tid: 5, cid: 0, did: 1, region: "Cleveland", name: "Curses", abbrev: "CLE", pop: 1.9},
-            {tid: 6, cid: 1, did: 3, region: "Dallas", name: "Snipers", abbrev: "DAL", pop: 4.7},
-            {tid: 7, cid: 1, did: 4, region: "Denver", name: "High", abbrev: "DEN", pop: 2.2},
-            {tid: 8, cid: 0, did: 1, region: "Detroit", name: "Muscle", abbrev: "DET", pop: 4.0},
-            {tid: 9, cid: 1, did: 3, region: "Houston", name: "Apollos", abbrev: "HOU", pop: 4.3},
-            {tid: 10, cid: 1, did: 5, region: "Las Vegas", name: "Blue Chips", abbrev: "LV", pop: 1.7},
-            {tid: 11, cid: 1, did: 5, region: "Los Angeles", name: "Earthquakes", abbrev: "LA", pop: 12.3},
-            {tid: 12, cid: 1, did: 3, region: "Mexico City", name: "Aztecs", abbrev: "MXC", pop: 19.4},
-            {tid: 13, cid: 0, did: 2, region: "Miami", name: "Cyclones", abbrev: "MIA", pop: 5.4},
-            {tid: 14, cid: 1, did: 4, region: "Minneapolis", name: "Blizzards", abbrev: "MIN", pop: 2.6},
-            {tid: 15, cid: 0, did: 0, region: "Montreal", name: "Mounties", abbrev: "MON", pop: 4.0},
-            {tid: 16, cid: 0, did: 0, region: "New York", name: "Bankers", abbrev: "NYC", pop: 18.7},
-            {tid: 17, cid: 0, did: 0, region: "Philadelphia", name: "Cheesesteaks", abbrev: "PHI", pop: 5.4},
-            {tid: 18, cid: 1, did: 3, region: "Phoenix", name: "Vultures", abbrev: "PHO", pop: 3.4},
-            {tid: 19, cid: 0, did: 1, region: "Pittsburgh", name: "Rivers", abbrev: "PIT", pop: 1.8},
-            {tid: 20, cid: 1, did: 4, region: "Portland", name: "Roses", abbrev: "POR", pop: 1.8},
-            {tid: 21, cid: 1, did: 5, region: "Sacramento", name: "Gold Rush", abbrev: "SAC", pop: 1.6},
-            {tid: 22, cid: 1, did: 5, region: "San Diego", name: "Pandas", abbrev: "SD", pop: 2.9},
-            {tid: 23, cid: 1, did: 5, region: "San Francisco", name: "Venture Capitalists", abbrev: "SF", pop: 3.4},
-            {tid: 24, cid: 1, did: 4, region: "Seattle", name: "Symphony", abbrev: "SEA", pop: 3.0},
-            {tid: 25, cid: 1, did: 3, region: "St. Louis", name: "Spirits", abbrev: "STL", pop: 2.2},
-            {tid: 26, cid: 0, did: 2, region: "Tampa", name: "Turtles", abbrev: "TPA", pop: 2.2},
-            {tid: 27, cid: 0, did: 0, region: "Toronto", name: "Beavers", abbrev: "TOR", pop: 6.3},
-            {tid: 28, cid: 1, did: 4, region: "Vancouver", name: "Whalers", abbrev: "VAN", pop: 2.3},
-            {tid: 29, cid: 0, did: 2, region: "Washington", name: "Monuments", abbrev: "WAS", pop: 4.2}
-        ];
+        teams = [{
+            tid: 0,
+            cid: 0,
+            did: 2,
+            region: "Atlanta",
+            name: "Gold Club",
+            abbrev: "ATL",
+            pop: 4.3
+        }, {
+            tid: 1,
+            cid: 0,
+            did: 2,
+            region: "Baltimore",
+            name: "Crabs",
+            abbrev: "BAL",
+            pop: 2.2
+        }, {
+            tid: 2,
+            cid: 0,
+            did: 0,
+            region: "Boston",
+            name: "Massacre",
+            abbrev: "BOS",
+            pop: 4.4
+        }, {
+            tid: 3,
+            cid: 0,
+            did: 1,
+            region: "Chicago",
+            name: "Whirlwinds",
+            abbrev: "CHI",
+            pop: 8.8
+        }, {
+            tid: 4,
+            cid: 0,
+            did: 1,
+            region: "Cincinnati",
+            name: "Riots",
+            abbrev: "CIN",
+            pop: 1.6
+        }, {
+            tid: 5,
+            cid: 0,
+            did: 1,
+            region: "Cleveland",
+            name: "Curses",
+            abbrev: "CLE",
+            pop: 1.9
+        }, {
+            tid: 6,
+            cid: 1,
+            did: 3,
+            region: "Dallas",
+            name: "Snipers",
+            abbrev: "DAL",
+            pop: 4.7
+        }, {
+            tid: 7,
+            cid: 1,
+            did: 4,
+            region: "Denver",
+            name: "High",
+            abbrev: "DEN",
+            pop: 2.2
+        }, {
+            tid: 8,
+            cid: 0,
+            did: 1,
+            region: "Detroit",
+            name: "Muscle",
+            abbrev: "DET",
+            pop: 4.0
+        }, {
+            tid: 9,
+            cid: 1,
+            did: 3,
+            region: "Houston",
+            name: "Apollos",
+            abbrev: "HOU",
+            pop: 4.3
+        }, {
+            tid: 10,
+            cid: 1,
+            did: 5,
+            region: "Las Vegas",
+            name: "Blue Chips",
+            abbrev: "LV",
+            pop: 1.7
+        }, {
+            tid: 11,
+            cid: 1,
+            did: 5,
+            region: "Los Angeles",
+            name: "Earthquakes",
+            abbrev: "LA",
+            pop: 12.3
+        }, {
+            tid: 12,
+            cid: 1,
+            did: 3,
+            region: "Mexico City",
+            name: "Aztecs",
+            abbrev: "MXC",
+            pop: 19.4
+        }, {
+            tid: 13,
+            cid: 0,
+            did: 2,
+            region: "Miami",
+            name: "Cyclones",
+            abbrev: "MIA",
+            pop: 5.4
+        }, {
+            tid: 14,
+            cid: 1,
+            did: 4,
+            region: "Minneapolis",
+            name: "Blizzards",
+            abbrev: "MIN",
+            pop: 2.6
+        }, {
+            tid: 15,
+            cid: 0,
+            did: 0,
+            region: "Montreal",
+            name: "Mounties",
+            abbrev: "MON",
+            pop: 4.0
+        }, {
+            tid: 16,
+            cid: 0,
+            did: 0,
+            region: "New York",
+            name: "Bankers",
+            abbrev: "NYC",
+            pop: 18.7
+        }, {
+            tid: 17,
+            cid: 0,
+            did: 0,
+            region: "Philadelphia",
+            name: "Cheesesteaks",
+            abbrev: "PHI",
+            pop: 5.4
+        }, {
+            tid: 18,
+            cid: 1,
+            did: 3,
+            region: "Phoenix",
+            name: "Vultures",
+            abbrev: "PHO",
+            pop: 3.4
+        }, {
+            tid: 19,
+            cid: 0,
+            did: 1,
+            region: "Pittsburgh",
+            name: "Rivers",
+            abbrev: "PIT",
+            pop: 1.8
+        }, {
+            tid: 20,
+            cid: 1,
+            did: 4,
+            region: "Portland",
+            name: "Roses",
+            abbrev: "POR",
+            pop: 1.8
+        }, {
+            tid: 21,
+            cid: 1,
+            did: 5,
+            region: "Sacramento",
+            name: "Gold Rush",
+            abbrev: "SAC",
+            pop: 1.6
+        }, {
+            tid: 22,
+            cid: 1,
+            did: 5,
+            region: "San Diego",
+            name: "Pandas",
+            abbrev: "SD",
+            pop: 2.9
+        }, {
+            tid: 23,
+            cid: 1,
+            did: 5,
+            region: "San Francisco",
+            name: "Venture Capitalists",
+            abbrev: "SF",
+            pop: 3.4
+        }, {
+            tid: 24,
+            cid: 1,
+            did: 4,
+            region: "Seattle",
+            name: "Symphony",
+            abbrev: "SEA",
+            pop: 3.0
+        }, {
+            tid: 25,
+            cid: 1,
+            did: 3,
+            region: "St. Louis",
+            name: "Spirits",
+            abbrev: "STL",
+            pop: 2.2
+        }, {
+            tid: 26,
+            cid: 0,
+            did: 2,
+            region: "Tampa",
+            name: "Turtles",
+            abbrev: "TPA",
+            pop: 2.2
+        }, {
+            tid: 27,
+            cid: 0,
+            did: 0,
+            region: "Toronto",
+            name: "Beavers",
+            abbrev: "TOR",
+            pop: 6.3
+        }, {
+            tid: 28,
+            cid: 1,
+            did: 4,
+            region: "Vancouver",
+            name: "Whalers",
+            abbrev: "VAN",
+            pop: 2.3
+        }, {
+            tid: 29,
+            cid: 0,
+            did: 2,
+            region: "Washington",
+            name: "Monuments",
+            abbrev: "WAS",
+            pop: 4.2
+        }];
 
         teams = addPopRank(teams);
 
@@ -263,8 +477,12 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
     function deepCopy(obj) {
         var key, retVal;
 
-        if (typeof obj !== "object" || obj === null) { return obj; }
-        if (obj.constructor === RegExp) { return obj; }
+        if (typeof obj !== "object" || obj === null) {
+            return obj;
+        }
+        if (obj.constructor === RegExp) {
+            return obj;
+        }
 
         retVal = new obj.constructor();
         for (key in obj) {
@@ -296,7 +514,9 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
 
         contentEl = document.getElementById("content");
         ko.cleanNode(contentEl);
-        ko.applyBindings({error: req.params.error}, contentEl);
+        ko.applyBindings({
+            error: req.params.error
+        }, contentEl);
         ui.title("Error");
         req.raw.cb();
     }
@@ -323,7 +543,9 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
 
             contentEl = document.getElementById("league_content");
             ko.cleanNode(contentEl);
-            ko.applyBindings({error: req.params.error}, contentEl);
+            ko.applyBindings({
+                error: req.params.error
+            }, contentEl);
             ui.title("Error");
             req.raw.cb();
         });
@@ -344,7 +566,14 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
 
         forceGlobal = forceGlobal !== undefined ? forceGlobal : false;
 
-        req = {params: {error: errorText}, raw: {cb: cb !== undefined ? cb : function () {}}};
+        req = {
+            params: {
+                error: errorText
+            },
+            raw: {
+                cb: cb !== undefined ? cb : function () {}
+            }
+        };
 
         lid = location.pathname.split("/")[2]; // lid derived from URL
         if (/^\d+$/.test(lid) && typeof indexedDB !== "undefined" && !forceGlobal) { // Show global error of no IndexedDB
@@ -731,8 +960,20 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
         game.tid = game.tid !== undefined ? game.tid : g.userTid;
 
         // team0 and team1 are different than they are above! Here it refers to user and opponent, not home and away
-        team0 = {tid: game.tid, abbrev: g.teamAbbrevsCache[game.tid], region: g.teamRegionsCache[game.tid], name: g.teamNamesCache[game.tid], pts: game.pts};
-        team1 = {tid: game.oppTid, abbrev: g.teamAbbrevsCache[game.oppTid], region: g.teamRegionsCache[game.oppTid], name: g.teamNamesCache[game.oppTid], pts: game.oppPts};
+        team0 = {
+            tid: game.tid,
+            abbrev: g.teamAbbrevsCache[game.tid],
+            region: g.teamRegionsCache[game.tid],
+            name: g.teamNamesCache[game.tid],
+            pts: game.pts
+        };
+        team1 = {
+            tid: game.oppTid,
+            abbrev: g.teamAbbrevsCache[game.oppTid],
+            region: g.teamRegionsCache[game.oppTid],
+            name: g.teamNamesCache[game.oppTid],
+            pts: game.oppPts
+        };
 
         output = {
             gid: game.gid,
@@ -815,39 +1056,39 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
                     }
 
                     // Hard crash
-/*                    gSend = JSON.parse(JSON.stringify(g)); // deepCopy fails for some reason
-                    delete gSend.teamAbbrevsCache;
-                    delete gSend.teamRegionsCache;
-                    delete gSend.teamNamesCache;
+                    /*                    gSend = JSON.parse(JSON.stringify(g)); // deepCopy fails for some reason
+                                        delete gSend.teamAbbrevsCache;
+                                        delete gSend.teamRegionsCache;
+                                        delete gSend.teamNamesCache;
 
-                    output = "<h1>Critical Error</h1><p>You ran into the infamous NaN bug. But there's good news! You can help fix it! Please email the following information to <a href=\"mailto:commissioner@basketball-gm.com\">commissioner@basketball-gm.com</a> along with any information about what you think might have caused this glitch. If you want to be extra helpful, <a href=\"" + leagueUrl(["export_league"]) + "\">export your league</a> and send that too (if it's huge, upload to Google Drive or Dropbox or whatever). Thanks!</p>";
+                                        output = "<h1>Critical Error</h1><p>You ran into the infamous NaN bug. But there's good news! You can help fix it! Please email the following information to <a href=\"mailto:commissioner@basketball-gm.com\">commissioner@basketball-gm.com</a> along with any information about what you think might have caused this glitch. If you want to be extra helpful, <a href=\"" + leagueUrl(["export_league"]) + "\">export your league</a> and send that too (if it's huge, upload to Google Drive or Dropbox or whatever). Thanks!</p>";
 
-                    output += '<textarea class="form-control" style="height: 300px">';
-                    output += JSON.stringify({
-                        stack: err.stack,
-                        input: obj,
-                        "this": this,
-                        gSend: gSend
-                    }, function (key, value) {
-                        if (value != value) {
-                            return "NaN RIGHT HERE";
-                        }
+                                        output += '<textarea class="form-control" style="height: 300px">';
+                                        output += JSON.stringify({
+                                            stack: err.stack,
+                                            input: obj,
+                                            "this": this,
+                                            gSend: gSend
+                                        }, function (key, value) {
+                                            if (value != value) {
+                                                return "NaN RIGHT HERE";
+                                            }
 
-                        return value;
-                    }, 2);
-                    output += "</textarea>";
+                                            return value;
+                                        }, 2);
+                                        output += "</textarea>";
 
-                    // Find somewhere to show output
-                    contentNode = document.getElementById("league_content");
-                    if (!contentNode) {
-                        contentNode = document.getElementById("content");
-                    }
-                    if (!contentNode) {
-                        contentNode = document.body;
-                    }
-                    contentNode.innerHTML = output;
+                                        // Find somewhere to show output
+                                        contentNode = document.getElementById("league_content");
+                                        if (!contentNode) {
+                                            contentNode = document.getElementById("content");
+                                        }
+                                        if (!contentNode) {
+                                            contentNode = document.body;
+                                        }
+                                        contentNode.innerHTML = output;
 
-                    throw err;*/
+                                        throw err;*/
 
                     // Try to recover gracefully
                     checkObject(obj, false, true); // This will update obj
@@ -878,7 +1119,9 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
     }
 
     function plusMinus(arg, d) {
-        if (arg !== arg) { return ""; }
+        if (arg !== arg) {
+            return "";
+        }
         return (arg > 0 ? "+" : "") + round(arg, d);
     }
 
@@ -889,11 +1132,10 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
      * @param {Array of String fields} sortBy sorting fields in order of application
      */
     function MultiSort(sortBy) {
-
         sortBy = sortBy;
 
         this.sortF = function (a, b) {
-            var result, sortT, rev, i;
+            var i, result, rev, sortT;
 
             for (i = 0; i < sortBy.length; i++) {
                 if (sortBy[i].indexOf("-") === 0) {
@@ -918,15 +1160,18 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
      * ocwinp and diff will get HCA regardless of seeding.
      */
     function seriesHomeAway(series, teamsConf, seed1, seed2, order, cid) {
-        var teams, sortBy, sorter;
+        var sortBy, sorter, teams;
         sortBy = ['winp', 'cwinp', 'ocwinp', 'diff'];
-        teams = [teamsConf[seed1-1], teamsConf[seed2-1]];
-        teams[0].seed =  seed1;
+        teams = [teamsConf[seed1 - 1], teamsConf[seed2 - 1]];
+        teams[0].seed = seed1;
         teams[1].seed = seed2;
         sorter = new MultiSort(sortBy);
         teams.sort(sorter.sortF);
 
-        series[0][order + cid * 4] = {home: teams[0], away: teams[1]};
+        series[0][order + cid * 4] = {
+            home: teams[0],
+            away: teams[1]
+        };
         series[0][order + cid * 4].home.seed = teams[0].seed;
         series[0][order + cid * 4].away.seed = teams[1].seed;
     }

--- a/js/util/helpers.js
+++ b/js/util/helpers.js
@@ -882,6 +882,49 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
         return (arg > 0 ? "+" : "") + round(arg, d);
     }
 
+    function MultiSort(sortBy) {
+
+        sortBy = sortBy;
+
+        this.sortF = function (a, b) {
+            var result, sortT, rev, i;
+
+            for (i = 0; i < sortBy.length; i++) {
+                if (sortBy[i].indexOf("-") === 0) {
+                    rev = true;
+                    sortT = sortBy[i].slice(1);
+                } else {
+                    rev = false;
+                    sortT = sortBy[i];
+                }
+
+                result = (rev) ? a[sortT] - b[sortT] : b[sortT] - a[sortT];
+
+                if (result || i === sortBy.length - 1) {
+                    if (sortT !== 'winpp') {
+                        console.log(a.region, b.region, sortT, result);
+                    }
+                    return result;
+                }
+            }
+        };
+    }
+
+    function seriesHomeAway(series, teamsConf, seed1, seed2, order, cid) {
+        var teams, sortBy, sorter;
+        sortBy = ['winp', 'cwinp', 'ocwinp', 'diff'];
+        teams = [teamsConf[seed1-1], teamsConf[seed2-1]];
+        teams[0].seed =  seed1;
+        teams[1].seed = seed2;
+        sorter = new MultiSort(sortBy);
+        teams.sort(sorter.sortF);
+
+        console.log('series', teams[0].region, teams[1].region);
+        series[0][order + cid * 4] = {home: teams[0], away: teams[1]};
+        series[0][order + cid * 4].home.seed = teams[0].seed;
+        series[0][order + cid * 4].away.seed = teams[1].seed;
+    }
+
     return {
         validateAbbrev: validateAbbrev,
         getAbbrev: getAbbrev,
@@ -914,6 +957,8 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
         checkNaNs: checkNaNs,
         gameScore: gameScore,
         updateMultiTeam: updateMultiTeam,
-        plusMinus: plusMinus
+        plusMinus: plusMinus,
+        seriesHomeAway: seriesHomeAway,
+        MultiSort: MultiSort
     };
 });

--- a/js/util/helpers.js
+++ b/js/util/helpers.js
@@ -901,9 +901,6 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
                 result = (rev) ? a[sortT] - b[sortT] : b[sortT] - a[sortT];
 
                 if (result || i === sortBy.length - 1) {
-                    if (sortT !== 'winpp') {
-                        console.log(a.region, b.region, sortT, result);
-                    }
                     return result;
                 }
             }
@@ -919,7 +916,6 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
         sorter = new MultiSort(sortBy);
         teams.sort(sorter.sortF);
 
-        console.log('series', teams[0].region, teams[1].region);
         series[0][order + cid * 4] = {home: teams[0], away: teams[1]};
         series[0][order + cid * 4].home.seed = teams[0].seed;
         series[0][order + cid * 4].away.seed = teams[1].seed;

--- a/js/util/helpers.js
+++ b/js/util/helpers.js
@@ -258,6 +258,21 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
     }
 
     /**
+     * Returns default playoff sorting. Adds 'drank' when global option
+     * divLeaderTop4 is true.
+     * @return {Array.<String>} Field names for sorting playoffs/standings.
+     */
+    function getPlayoffSorting() {
+        var sortBy;
+        if (g.divLeaderTop4) {
+            sortBy = ["winp", "drank", "cwinp", "ocwinp", "diff"]
+        } else {
+            sortBy = ["winp", "cwinp", "ocwinp", "diff"]
+        }
+        return sortBy;
+    }
+
+    /**
      * Clones an object.
      *
      * Taken from http://stackoverflow.com/a/3284324/786644
@@ -974,6 +989,7 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
         getTeams: getTeams,
         addPopRank: addPopRank,
         getTeamsDefault: getTeamsDefault,
+        getPlayoffSorting: getPlayoffSorting,
         deepCopy: deepCopy,
         error: error,
         errorNotify: errorNotify,

--- a/js/util/helpers.js
+++ b/js/util/helpers.js
@@ -219,247 +219,38 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
     function getTeamsDefault() {
         var teams;
 
-        teams = [{
-            tid: 0,
-            cid: 0,
-            did: 2,
-            region: "Atlanta",
-            name: "Gold Club",
-            abbrev: "ATL",
-            pop: 4.3
-        }, {
-            tid: 1,
-            cid: 0,
-            did: 2,
-            region: "Baltimore",
-            name: "Crabs",
-            abbrev: "BAL",
-            pop: 2.2
-        }, {
-            tid: 2,
-            cid: 0,
-            did: 0,
-            region: "Boston",
-            name: "Massacre",
-            abbrev: "BOS",
-            pop: 4.4
-        }, {
-            tid: 3,
-            cid: 0,
-            did: 1,
-            region: "Chicago",
-            name: "Whirlwinds",
-            abbrev: "CHI",
-            pop: 8.8
-        }, {
-            tid: 4,
-            cid: 0,
-            did: 1,
-            region: "Cincinnati",
-            name: "Riots",
-            abbrev: "CIN",
-            pop: 1.6
-        }, {
-            tid: 5,
-            cid: 0,
-            did: 1,
-            region: "Cleveland",
-            name: "Curses",
-            abbrev: "CLE",
-            pop: 1.9
-        }, {
-            tid: 6,
-            cid: 1,
-            did: 3,
-            region: "Dallas",
-            name: "Snipers",
-            abbrev: "DAL",
-            pop: 4.7
-        }, {
-            tid: 7,
-            cid: 1,
-            did: 4,
-            region: "Denver",
-            name: "High",
-            abbrev: "DEN",
-            pop: 2.2
-        }, {
-            tid: 8,
-            cid: 0,
-            did: 1,
-            region: "Detroit",
-            name: "Muscle",
-            abbrev: "DET",
-            pop: 4.0
-        }, {
-            tid: 9,
-            cid: 1,
-            did: 3,
-            region: "Houston",
-            name: "Apollos",
-            abbrev: "HOU",
-            pop: 4.3
-        }, {
-            tid: 10,
-            cid: 1,
-            did: 5,
-            region: "Las Vegas",
-            name: "Blue Chips",
-            abbrev: "LV",
-            pop: 1.7
-        }, {
-            tid: 11,
-            cid: 1,
-            did: 5,
-            region: "Los Angeles",
-            name: "Earthquakes",
-            abbrev: "LA",
-            pop: 12.3
-        }, {
-            tid: 12,
-            cid: 1,
-            did: 3,
-            region: "Mexico City",
-            name: "Aztecs",
-            abbrev: "MXC",
-            pop: 19.4
-        }, {
-            tid: 13,
-            cid: 0,
-            did: 2,
-            region: "Miami",
-            name: "Cyclones",
-            abbrev: "MIA",
-            pop: 5.4
-        }, {
-            tid: 14,
-            cid: 1,
-            did: 4,
-            region: "Minneapolis",
-            name: "Blizzards",
-            abbrev: "MIN",
-            pop: 2.6
-        }, {
-            tid: 15,
-            cid: 0,
-            did: 0,
-            region: "Montreal",
-            name: "Mounties",
-            abbrev: "MON",
-            pop: 4.0
-        }, {
-            tid: 16,
-            cid: 0,
-            did: 0,
-            region: "New York",
-            name: "Bankers",
-            abbrev: "NYC",
-            pop: 18.7
-        }, {
-            tid: 17,
-            cid: 0,
-            did: 0,
-            region: "Philadelphia",
-            name: "Cheesesteaks",
-            abbrev: "PHI",
-            pop: 5.4
-        }, {
-            tid: 18,
-            cid: 1,
-            did: 3,
-            region: "Phoenix",
-            name: "Vultures",
-            abbrev: "PHO",
-            pop: 3.4
-        }, {
-            tid: 19,
-            cid: 0,
-            did: 1,
-            region: "Pittsburgh",
-            name: "Rivers",
-            abbrev: "PIT",
-            pop: 1.8
-        }, {
-            tid: 20,
-            cid: 1,
-            did: 4,
-            region: "Portland",
-            name: "Roses",
-            abbrev: "POR",
-            pop: 1.8
-        }, {
-            tid: 21,
-            cid: 1,
-            did: 5,
-            region: "Sacramento",
-            name: "Gold Rush",
-            abbrev: "SAC",
-            pop: 1.6
-        }, {
-            tid: 22,
-            cid: 1,
-            did: 5,
-            region: "San Diego",
-            name: "Pandas",
-            abbrev: "SD",
-            pop: 2.9
-        }, {
-            tid: 23,
-            cid: 1,
-            did: 5,
-            region: "San Francisco",
-            name: "Venture Capitalists",
-            abbrev: "SF",
-            pop: 3.4
-        }, {
-            tid: 24,
-            cid: 1,
-            did: 4,
-            region: "Seattle",
-            name: "Symphony",
-            abbrev: "SEA",
-            pop: 3.0
-        }, {
-            tid: 25,
-            cid: 1,
-            did: 3,
-            region: "St. Louis",
-            name: "Spirits",
-            abbrev: "STL",
-            pop: 2.2
-        }, {
-            tid: 26,
-            cid: 0,
-            did: 2,
-            region: "Tampa",
-            name: "Turtles",
-            abbrev: "TPA",
-            pop: 2.2
-        }, {
-            tid: 27,
-            cid: 0,
-            did: 0,
-            region: "Toronto",
-            name: "Beavers",
-            abbrev: "TOR",
-            pop: 6.3
-        }, {
-            tid: 28,
-            cid: 1,
-            did: 4,
-            region: "Vancouver",
-            name: "Whalers",
-            abbrev: "VAN",
-            pop: 2.3
-        }, {
-            tid: 29,
-            cid: 0,
-            did: 2,
-            region: "Washington",
-            name: "Monuments",
-            abbrev: "WAS",
-            pop: 4.2
-        }];
+        teams = [
+            {tid: 0, cid: 0, did: 2, region: "Atlanta", name: "Gold Club", abbrev: "ATL", pop: 4.3},
+            {tid: 1, cid: 0, did: 2, region: "Baltimore", name: "Crabs", abbrev: "BAL", pop: 2.2},
+            {tid: 2, cid: 0, did: 0, region: "Boston", name: "Massacre", abbrev: "BOS", pop: 4.4},
+            {tid: 3, cid: 0, did: 1, region: "Chicago", name: "Whirlwinds", abbrev: "CHI", pop: 8.8},
+            {tid: 4, cid: 0, did: 1, region: "Cincinnati", name: "Riots", abbrev: "CIN", pop: 1.6},
+            {tid: 5, cid: 0, did: 1, region: "Cleveland", name: "Curses", abbrev: "CLE", pop: 1.9},
+            {tid: 6, cid: 1, did: 3, region: "Dallas", name: "Snipers", abbrev: "DAL", pop: 4.7},
+            {tid: 7, cid: 1, did: 4, region: "Denver", name: "High", abbrev: "DEN", pop: 2.2},
+            {tid: 8, cid: 0, did: 1, region: "Detroit", name: "Muscle", abbrev: "DET", pop: 4.0},
+            {tid: 9, cid: 1, did: 3, region: "Houston", name: "Apollos", abbrev: "HOU", pop: 4.3},
+            {tid: 10, cid: 1, did: 5, region: "Las Vegas", name: "Blue Chips", abbrev: "LV", pop: 1.7},
+            {tid: 11, cid: 1, did: 5, region: "Los Angeles", name: "Earthquakes", abbrev: "LA", pop: 12.3},
+            {tid: 12, cid: 1, did: 3, region: "Mexico City", name: "Aztecs", abbrev: "MXC", pop: 19.4},
+            {tid: 13, cid: 0, did: 2, region: "Miami", name: "Cyclones", abbrev: "MIA", pop: 5.4},
+            {tid: 14, cid: 1, did: 4, region: "Minneapolis", name: "Blizzards", abbrev: "MIN", pop: 2.6},
+            {tid: 15, cid: 0, did: 0, region: "Montreal", name: "Mounties", abbrev: "MON", pop: 4.0},
+            {tid: 16, cid: 0, did: 0, region: "New York", name: "Bankers", abbrev: "NYC", pop: 18.7},
+            {tid: 17, cid: 0, did: 0, region: "Philadelphia", name: "Cheesesteaks", abbrev: "PHI", pop: 5.4},
+            {tid: 18, cid: 1, did: 3, region: "Phoenix", name: "Vultures", abbrev: "PHO", pop: 3.4},
+            {tid: 19, cid: 0, did: 1, region: "Pittsburgh", name: "Rivers", abbrev: "PIT", pop: 1.8},
+            {tid: 20, cid: 1, did: 4, region: "Portland", name: "Roses", abbrev: "POR", pop: 1.8},
+            {tid: 21, cid: 1, did: 5, region: "Sacramento", name: "Gold Rush", abbrev: "SAC", pop: 1.6},
+            {tid: 22, cid: 1, did: 5, region: "San Diego", name: "Pandas", abbrev: "SD", pop: 2.9},
+            {tid: 23, cid: 1, did: 5, region: "San Francisco", name: "Venture Capitalists", abbrev: "SF", pop: 3.4},
+            {tid: 24, cid: 1, did: 4, region: "Seattle", name: "Symphony", abbrev: "SEA", pop: 3.0},
+            {tid: 25, cid: 1, did: 3, region: "St. Louis", name: "Spirits", abbrev: "STL", pop: 2.2},
+            {tid: 26, cid: 0, did: 2, region: "Tampa", name: "Turtles", abbrev: "TPA", pop: 2.2},
+            {tid: 27, cid: 0, did: 0, region: "Toronto", name: "Beavers", abbrev: "TOR", pop: 6.3},
+            {tid: 28, cid: 1, did: 4, region: "Vancouver", name: "Whalers", abbrev: "VAN", pop: 2.3},
+            {tid: 29, cid: 0, did: 2, region: "Washington", name: "Monuments", abbrev: "WAS", pop: 4.2}
+        ];
 
         teams = addPopRank(teams);
 
@@ -1056,39 +847,39 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
                     }
 
                     // Hard crash
-                    /*                    gSend = JSON.parse(JSON.stringify(g)); // deepCopy fails for some reason
-                                        delete gSend.teamAbbrevsCache;
-                                        delete gSend.teamRegionsCache;
-                                        delete gSend.teamNamesCache;
+/*                  gSend = JSON.parse(JSON.stringify(g)); // deepCopy fails for some reason
+                    delete gSend.teamAbbrevsCache;
+                    delete gSend.teamRegionsCache;
+                    delete gSend.teamNamesCache;
 
-                                        output = "<h1>Critical Error</h1><p>You ran into the infamous NaN bug. But there's good news! You can help fix it! Please email the following information to <a href=\"mailto:commissioner@basketball-gm.com\">commissioner@basketball-gm.com</a> along with any information about what you think might have caused this glitch. If you want to be extra helpful, <a href=\"" + leagueUrl(["export_league"]) + "\">export your league</a> and send that too (if it's huge, upload to Google Drive or Dropbox or whatever). Thanks!</p>";
+                    output = "<h1>Critical Error</h1><p>You ran into the infamous NaN bug. But there's good news! You can help fix it! Please email the following information to <a href=\"mailto:commissioner@basketball-gm.com\">commissioner@basketball-gm.com</a> along with any information about what you think might have caused this glitch. If you want to be extra helpful, <a href=\"" + leagueUrl(["export_league"]) + "\">export your league</a> and send that too (if it's huge, upload to Google Drive or Dropbox or whatever). Thanks!</p>";
 
-                                        output += '<textarea class="form-control" style="height: 300px">';
-                                        output += JSON.stringify({
-                                            stack: err.stack,
-                                            input: obj,
-                                            "this": this,
-                                            gSend: gSend
-                                        }, function (key, value) {
-                                            if (value != value) {
-                                                return "NaN RIGHT HERE";
-                                            }
+                    output += '<textarea class="form-control" style="height: 300px">';
+                    output += JSON.stringify({
+                        stack: err.stack,
+                        input: obj,
+                        "this": this,
+                        gSend: gSend
+                    }, function (key, value) {
+                        if (value != value) {
+                            return "NaN RIGHT HERE";
+                        }
 
-                                            return value;
-                                        }, 2);
-                                        output += "</textarea>";
+                        return value;
+                    }, 2);
+                    output += "</textarea>";
 
-                                        // Find somewhere to show output
-                                        contentNode = document.getElementById("league_content");
-                                        if (!contentNode) {
-                                            contentNode = document.getElementById("content");
-                                        }
-                                        if (!contentNode) {
-                                            contentNode = document.body;
-                                        }
-                                        contentNode.innerHTML = output;
+                    // Find somewhere to show output
+                    contentNode = document.getElementById("league_content");
+                    if (!contentNode) {
+                        contentNode = document.getElementById("content");
+                    }
+                    if (!contentNode) {
+                        contentNode = document.body;
+                    }
+                    contentNode.innerHTML = output;
 
-                                        throw err;*/
+                    throw err;*/
 
                     // Try to recover gracefully
                     checkObject(obj, false, true); // This will update obj

--- a/js/util/helpers.js
+++ b/js/util/helpers.js
@@ -1126,15 +1126,13 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
     }
 
     /**
-     * Constructor for a sorter object. Use the objects sortF member as the sort
-     * function for the object list.
-     *
-     * @param {Array of String fields} sortBy sorting fields in order of application
+     * Return an anonymous function for sorting according to the order of sortBy
+     * @param  {Array of Strings} sortBy list of fields
      */
-    function MultiSort(sortBy) {
+    function multiSort(sortBy) {
         sortBy = sortBy;
 
-        this.sortF = function (a, b) {
+        return function (a, b) {
             var i, result, rev, sortT;
 
             for (i = 0; i < sortBy.length; i++) {
@@ -1165,8 +1163,8 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
         teams = [teamsConf[seed1 - 1], teamsConf[seed2 - 1]];
         teams[0].seed = seed1;
         teams[1].seed = seed2;
-        sorter = new MultiSort(sortBy);
-        teams.sort(sorter.sortF);
+        sorter = multiSort(sortBy);
+        teams.sort(sorter);
 
         series[0][order + cid * 4] = {
             home: teams[0],
@@ -1210,6 +1208,6 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
         updateMultiTeam: updateMultiTeam,
         plusMinus: plusMinus,
         seriesHomeAway: seriesHomeAway,
-        MultiSort: MultiSort
+        multiSort: multiSort
     };
 });

--- a/js/util/helpers.js
+++ b/js/util/helpers.js
@@ -265,9 +265,9 @@ define(["dao", "globals", "lib/knockout", "util/eventLog"], function (dao, g, ko
     function getPlayoffSorting() {
         var sortBy;
         if (g.divLeaderTop4) {
-            sortBy = ["winp", "drank", "cwinp", "ocwinp", "diff"]
+            sortBy = ["winp", "drank", "cwinp", "ocwinp", "diff"];
         } else {
-            sortBy = ["winp", "cwinp", "ocwinp", "diff"]
+            sortBy = ["winp", "cwinp", "ocwinp", "diff"];
         }
         return sortBy;
     }

--- a/js/views/leagueDashboard.js
+++ b/js/views/leagueDashboard.js
@@ -323,7 +323,7 @@ define(["dao", "globals", "ui", "core/player", "core/season", "core/team", "lib/
                 attrs: ["tid", "cid", "abbrev", "region"],
                 seasonAttrs: ["won", "lost", "winp"],
                 season: g.season,
-                sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
+                sortBy: helpers.getPlayoffSorting()
             }).then(function (teams) {
                 var cid, confTeams, i, k, l;
 

--- a/js/views/leagueDashboard.js
+++ b/js/views/leagueDashboard.js
@@ -74,7 +74,7 @@ define(["dao", "globals", "ui", "core/player", "core/season", "core/team", "lib/
                 seasonAttrs: ["won", "lost", "winp", "att", "revenue", "profit"],
                 stats: stats,
                 season: g.season,
-                sortBy: ["winp", "-lost", "won"]
+                sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
             }).then(function (teams) {
                 var cid, i, j;
 
@@ -323,7 +323,7 @@ define(["dao", "globals", "ui", "core/player", "core/season", "core/team", "lib/
                 attrs: ["tid", "cid", "abbrev", "region"],
                 seasonAttrs: ["won", "lost", "winp"],
                 season: g.season,
-                sortBy: ["winp", "-lost", "won"]
+                sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
             }).then(function (teams) {
                 var cid, confTeams, i, k, l;
 

--- a/js/views/leagueDashboard.js
+++ b/js/views/leagueDashboard.js
@@ -74,7 +74,7 @@ define(["dao", "globals", "ui", "core/player", "core/season", "core/team", "lib/
                 seasonAttrs: ["won", "lost", "winp", "att", "revenue", "profit"],
                 stats: stats,
                 season: g.season,
-                sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
+                sortBy: helpers.getPlayoffSorting()
             }).then(function (teams) {
                 var cid, i, j;
 

--- a/js/views/playoffs.js
+++ b/js/views/playoffs.js
@@ -19,7 +19,7 @@ define(["dao", "globals", "ui", "core/team", "lib/knockout", "util/bbgmView", "u
                     attrs: ["tid", "cid", "abbrev", "name"],
                     seasonAttrs: ["winp"],
                     season: inputs.season,
-                    sortBy: ["winp", "-lost", "won"]
+                    sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
                 }).then(function (teams) {
                     var cid, i, series, teamsConf;
 

--- a/js/views/playoffs.js
+++ b/js/views/playoffs.js
@@ -19,7 +19,7 @@ define(["dao", "globals", "ui", "core/team", "lib/knockout", "util/bbgmView", "u
                     attrs: ["tid", "cid", "abbrev", "name"],
                     seasonAttrs: ["winp"],
                     season: inputs.season,
-                    sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
+                    sortBy: helpers.getPlayoffSorting()
                 }).then(function (teams) {
                     var cid, i, series, teamsConf;
 

--- a/js/views/standings.js
+++ b/js/views/standings.js
@@ -48,7 +48,7 @@ define(["globals", "ui", "core/team", "lib/jquery", "lib/knockout", "lib/knockou
                 attrs: ["tid", "cid", "did", "abbrev", "region", "name"],
                 seasonAttrs: ["won", "lost", "winp", "wonHome", "lostHome", "wonAway", "lostAway", "wonDiv", "lostDiv", "wonConf", "lostConf", "lastTen", "streak"],
                 season: inputs.season,
-                sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
+                sortBy: helpers.getPlayoffSorting()
             }).then(function (teams) {
                 var confRanks, confTeams, confs, divTeams, i, j, k, l;
 

--- a/js/views/standings.js
+++ b/js/views/standings.js
@@ -48,7 +48,7 @@ define(["globals", "ui", "core/team", "lib/jquery", "lib/knockout", "lib/knockou
                 attrs: ["tid", "cid", "did", "abbrev", "region", "name"],
                 seasonAttrs: ["won", "lost", "winp", "wonHome", "lostHome", "wonAway", "lostAway", "wonDiv", "lostDiv", "wonConf", "lostConf", "lastTen", "streak"],
                 season: inputs.season,
-                sortBy: ["winp", "-lost", "won"]
+                sortBy: ["winp", "drank", "cwinp", "ocwinp", "diff"]
             }).then(function (teams) {
                 var confRanks, confTeams, confs, divTeams, i, j, k, l;
 


### PR DESCRIPTION
Based on:  http://stats.nba.com/playoffpicture/

Rank teams by Win Percentage (winp), Division Leaders (drank), Conference Win Percentage(cwinp), Win Percentage against other conference (ocwinp) and Point Differential (diff). 

Division Leaders are assured of a top 4 seeding per conference but will lose Home Court Advantage during playoffs if their matchup has the better winp to diff etc. 

Like in RL, this makes the division titles have more significance especially in the playoffs. And tiebreakers are really needed as it affects who makes the playoffs and also the matchups.

Missing from this change is the implementation of the following
(2) Head-to-head won-lost percentage
(4) W-L Percentage vs. Playoff teams, own conference
(5) W-L Percentage vs. Playoff teams, other conference

Because I'm not sure if adding them would  have a significant change in the results (other than the significant data store load and I think many usually clear game data like myself upon reaching many seasons played.)
