### PR TITLE
match filter keyword to event keyword

### DIFF
--- a/src/js/views/components.js
+++ b/src/js/views/components.js
@@ -195,7 +195,7 @@ function dropdown(formId, fields, selected, updateEvents, extraParam) {
                     key: "reSigned"
                 }, {
                     val: "Released",
-                    key: "released"
+                    key: "release"
                 }, {
                     val: "Trades",
                     key: "trade"

--- a/src/js/views/transactions.js
+++ b/src/js/views/transactions.js
@@ -64,7 +64,7 @@ async function updateEventLog(inputs, updateEvents, vm) {
             }
 
             if (inputs.eventType === "all") {
-                events = events.filter(event => event.type === 'reSigned' || event.type === 'released' || event.type === 'trade' || event.type === 'freeAgent' || event.type === 'draft');
+                events = events.filter(event => event.type === 'reSigned' || event.type === 'release' || event.type === 'trade' || event.type === 'freeAgent' || event.type === 'draft');
             } else {
                 events = events.filter(event => event.type === inputs.eventType);
             }


### PR DESCRIPTION
`player.release` in core/player.js creates an event with the type "release"

Unfortunately...

`updateEventLog` in views/transactions.js filters for the event type "released"


Fixes issue #106. Bigger issue than views/transactions.js was the hard-coded "released" keyword in components.js that I had to trackdown.

Keeping in the spirit of backwards-compatibility, the events have already been emitting for months as the event type "release" so it's better to just edit the filters to make them correct, than to change the event log convention.