### PR TITLE
Define MIME types for images

### DIFF
--- a/tools/server.js
+++ b/tools/server.js
@@ -9,7 +9,11 @@ const mimeTypes = {
     '.js': 'text/javascript',
     '.map': 'application/json',
     '.html': 'text/html',
-    '.woff': 'application/font-woff'
+    '.woff': 'application/font-woff',
+    '.png': 'image/png',
+    '.jpeg': 'image/jpeg',
+    '.bmp': 'image/bmp',
+    '.gif': 'image/gif'
 };
 const sendFile = (res, filename) => {
     const ext = path.extname(filename);


### PR DESCRIPTION
I was getting annoyed by the console logs being thrown every time I visited my team's roster. I've checked to make sure that default logos, random faces, and URL logos and URL player profile pics are still loading correctly.

I've also added MIME types for things we don't use, like gif. Let's see some animated rosters, yo.

https://gfycat.com/WarmheartedAgonizingFox
