### PR TITLE
Finished converting bbgm.scss from CSS to Sass format

### DIFF
--- a/src/css/DT_bootstrap.css
+++ b/src/css/DT_bootstrap.css
@@ -1,36 +1,36 @@
 
 div.dataTables_length label {
-	font-weight: normal;
-	float: left;
-	text-align: left;
+  font-weight: normal;
+  float: left;
+  text-align: left;
 }
 
 div.dataTables_length select {
-	display: inline-block;
-/* Doesn't seem to be needed:	width: 75px; */
+  display: inline-block;
+/* Doesn't seem to be needed: width: 75px; */
 }
 
 div.dataTables_filter label {
-	float: right;
+  float: right;
 }
 
 div.dataTables_info {
-	padding-top: 8px;
+  padding-top: 8px;
     float: left;
 }
 
 div.dataTables_paginate {
-	float: right;
-	margin: 0;
+  float: right;
+  margin: 0;
 }
 
 ul.pagination {
-	margin: 0;
+  margin: 0;
 }
 
 table.table {
-	clear: both;
-	margin-bottom: 6px !important;
+  clear: both;
+  margin-bottom: 6px !important;
 }
 
 table.table thead .sorting,
@@ -38,11 +38,11 @@ table.table thead .sorting_asc,
 table.table thead .sorting_desc,
 table.table thead .sorting_asc_disabled,
 table.table thead .sorting_desc_disabled {
-	cursor: pointer;
-	*cursor: hand;
-	user-select: none;
-	-moz-user-select: none;
-	-webkit-user-select: none;
+  cursor: pointer;
+  *cursor: hand;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
 }
 
 table.table thead .sorting { background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6MTRDMDM5NjkyMkMxMTFFMUExRjFBREFENUIyQTUzOEMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6MTRDMDM5NkEyMkMxMTFFMUExRjFBREFENUIyQTUzOEMiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDoxNEMwMzk2NzIyQzExMUUxQTFGMUFEQUQ1QjJBNTM4QyIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDoxNEMwMzk2ODIyQzExMUUxQTFGMUFEQUQ1QjJBNTM4QyIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pm8NGvcAAADkSURBVHjaYvz//z8DtQATAxUBCzbBu3fvInO5gLgNiMuA+BdMUFlZmSyXZQNxFhCnUupNLSDOA2JWIC4AOYhcwxiBuBiIZaB8FajBjOQY5gDEgWhiiUBsTaphvEBcC8SCWMRrgJidFMNCoC74gQU7AnEQ1nChZqLFlc4igdQCIP6HwzcZwHQ2n1hvrgPi/UDMgQUfBeI1pITZTyBuAeLPaOLvgbgZizjBpAFyAbpX1gPxAXLSGShmJgHxHSj/CRD3QsXJyk6gHD8BiH9DDb5GcmyigdlArArEUwkpZBy0hSNAgAEA5Ho0sMdEmU8AAAAASUVORK5CYII=) no-repeat center right; }
@@ -53,9 +53,9 @@ table.table thead .sorting_asc_disabled { background: url(data:image/png;base64,
 table.table thead .sorting_desc_disabled { background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABMAAAATCAYAAAByUDbMAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6NDNGQ0VGRjQyMkMxMTFFMUExRjFBREFENUIyQTUzOEMiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6NDNGQ0VGRjUyMkMxMTFFMUExRjFBREFENUIyQTUzOEMiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDoxNEMwMzk2QjIyQzExMUUxQTFGMUFEQUQ1QjJBNTM4QyIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDoxNEMwMzk2QzIyQzExMUUxQTFGMUFEQUQ1QjJBNTM4QyIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pnt2WfgAAACJSURBVHjaYvz//z8DtQATAxXBqGGjhtHDMBZsgnfv3o0EUguA+B8OB2QoKyvPJ9Zl64B4PxBzYMFHgXgNKd78CcQtQPwZTfw9EDdjEScYZiAXoHtlPRAfICcCQMXJJCC+A+U/AeJeqDhZsXkXiCcA8W+owddIjk00MBuIVYF4KiGFjIO2cAQIMAAzGSDTlIC38gAAAABJRU5ErkJggg==) no-repeat center right; }
 
 table.dataTable th:active {
-	outline: none;
+  outline: none;
 }
 
 div.dataTables_wrapper .table-responsive {
-	margin-bottom: 4px;
+  margin-bottom: 4px;
 }

--- a/src/css/bbgm.scss
+++ b/src/css/bbgm.scss
@@ -154,11 +154,11 @@ footer {
 }
 @media (max-width: 767px) {
   .user-menu {
-    margin-left: -15px; /* Move closer to hamburger menu */
+    margin-left: -15px; // Move closer to hamburger menu
   }
 }
 
-/* These colors are copied from the default "success" button. */
+// These colors are copied from the default "success" button.
 #play-button-link {
   color: #fff;
   background-color: #5cb85c;
@@ -170,7 +170,7 @@ footer {
   border-top-color: #fff;
 }
 
-/* This is for keyboard shortcuts in dropdowns */
+// This is for keyboard shortcuts in dropdowns
 .dropdown-menu > li > a {
   position: relative;
   padding-right: 70px;
@@ -233,7 +233,8 @@ ul.dashboard-boxes li.dashboard-box-new h2 {
   width: 180px;
 }
 
-/* From the Bootstrap offcanvas example http://getbootstrap.com/examples/offcanvas/ */
+// From the Bootstrap offcanvas example
+// http://getbootstrap.com/examples/offcanvas/
 @media screen and (max-width: 768px) {
   .row-offcanvas {
     position: relative;
@@ -302,7 +303,8 @@ table {
 #game-log-list td a {
   color: #3a87ad;
   display: block;
-  padding: 4px 5px 4px 5px;  /* Expand to encompass normal td padding, which was set to 0 here above. */
+  // Expand to encompass normal td padding, which was set to 0 here above.
+  padding: 4px 5px 4px 5px;
   text-decoration: none;
 }
 
@@ -349,7 +351,8 @@ table {
 .schedule-score {
   margin-left: 6px;
   font-size: 14px;
-  line-height: 36px; /* so bottom aligns despite float */
+  // so bottom aligns despite float
+  line-height: 36px;
 }
 .schedule-at {
   font-size: 22px;
@@ -359,19 +362,20 @@ table {
    width: auto;
 }
 
-/* Auto width seems to work well..
-select.season {
-  width: 125px;
-}
-select.seasons {
-  width: 125px;
-}
-select.past-x {
-  width: 135px;
-}
-select.teams {
-  width: 203px;
-}*/
+// Auto width seems to work well..
+//
+// select.season {
+//   width: 125px;
+// }
+// select.seasons {
+//   width: 125px;
+// }
+// select.past-x {
+//   width: 135px;
+// }
+// select.teams {
+//   width: 203px;
+// }
 
 #trade-summary {
   background-color: #fff;
@@ -397,7 +401,7 @@ select.teams {
 }
 
 .team-picture {
-  display: none; /* Hide by default, shown in views/roster.js */
+  display: none; // Hide by default, shown in views/roster.js
 	background-position: center center;
 	background-repeat: no-repeat;
 	background-size: contain;
@@ -435,7 +439,8 @@ select.teams {
   padding: 0;
   height: 20px;
 }
-/* These colors are duplicated from Roster.js */
+
+// These colors are duplicated from Roster.js
 .pt-modifier-select option[value="1"] {
   background-color: #ccc;
 }
@@ -478,7 +483,7 @@ select.teams {
   height: 100px;
 }
 
-/* From bootstrap */
+// From bootstrap
 .bar-graph-1 { background-color: #049cdb; }
 .bar-graph-2 { background-color: #f89406; }
 .bar-graph-3 { background-color: #9d261d; }
@@ -492,7 +497,7 @@ select.teams {
   cursor: pointer;
 }
 
-/* Stupid fix for popover in h4 */
+// Stupid fix for popover in h4
 .popover-content {
   font-size: 13px;
   font-weight: normal;
@@ -502,7 +507,7 @@ select.teams {
   margin-bottom: 0;
 }
 
-/* Stupid fix for popover on first run */
+// Stupid fix for popover on first run
 .popover-play {
   width: 276px;
 }
@@ -608,41 +613,47 @@ select.teams {
   font-weight: bold;
 }
 
-/* HACK so that the td.info class can be overriden in teamHistory (and possibly elsewhere). */
+// HACK so that the td.info class can be overriden in teamHistory (and possibly
+// elsewhere).
 tr.warning > td {
   background-color: #fcf8e3;
   border-color: #fbeed5;
 }
 
-/* Affix stuff taken from Bootstrap docs and used for the play-by-play in live gameSim */
-/* By default it's not affixed in mobile views, so undo that */
+// Affix stuff taken from Bootstrap docs and used for the play-by-play in live
+// gameSim.
+//
+// By default it's not affixed in mobile views, so undo that.
 .affix {
   position: static;
 }
-/* Show and affix the side nav when space allows it */
+
+// Show and affix the side nav when space allows it
 @media (min-width: 992px) {
-  /* Widen the fixed sidebar */
+  // Widen the fixed sidebar
   .affix,
   .affix-bottom {
     width: 213px;
   }
   .affix {
-    position: fixed; /* Undo the static from mobile first approach */
+    // Undo the static from mobile first approach
+    position: fixed;
     top: 60px;
   }
   .affix-bottom {
-    position: absolute; /* Undo the static from mobile first approach */
+    // Undo the static from mobile first approach
+    position: absolute;
   }
 }
 @media (min-width: 1200px) {
-  /* Widen the fixed sidebar again */
+  // Widen the fixed sidebar again
   .affix-bottom,
   .affix {
     width: 360px;
   }
 }
 
-/* Large screen sidebar, adapted from Bootstrap docs */
+// Large screen sidebar, adapted from Bootstrap docs
 .bs-sidenav {
   margin-top: 24px;
   padding-top: 10px;

--- a/src/css/bbgm.scss
+++ b/src/css/bbgm.scss
@@ -12,55 +12,78 @@ footer {
   margin-top: -7px;
 }
 
-.navbar-brand img {
-  vertical-align: top;
-}
-.navbar-brand span {
-  padding-left: 5px;
-  float: right;
+.navbar-brand {
+  img {
+    vertical-align: top;
+  }
+
+  span {
+    padding-left: 5px;
+    float: right;
+  }
 }
 
-/* This is like navbar-text, but with different margins so two lines of text can fit, and with no responsive stuff so it always shows in the navbar. */
+// This is like navbar-text, but with different margins so two lines of text can
+// fit, and with no responsive stuff so it always shows in the navbar.
 .navbar-text-two-line-no-collapse {
   color: #777777;
   float: left;
   margin: 6px 15px 7px 15px;
 }
 
-/* This is a copy of the navbar-nav styles, with no responsive stuff. */
-.navbar-collapse .navbar-nav-no-collapse.navbar-left:first-child {
-  margin-left: -15px;
+// This is a copy of the navbar-nav styles, with no responsive stuff.
+.navbar-collapse {
+  .navbar-nav-no-collapse.navbar-left:first-child {
+    margin-left: -15px;
+  }
+
+  .navbar-nav-no-collapse.navbar-right:last-child {
+    margin-right: -15px;
+  }
 }
-.navbar-collapse .navbar-nav-no-collapse.navbar-right:last-child {
-  margin-right: -15px;
-}
+
 .navbar-nav-no-collapse {
   margin: 8px -15px;
+
+  > li {
+    > a {
+      padding-top: 10px;
+      padding-bottom: 10px;
+      line-height: 18px;
+    }
+
+    > .dropdown-menu {
+      margin-top: 0;
+      border-top-right-radius: 0;
+      border-top-left-radius: 0;
+    }
+  }
 }
-.navbar-nav-no-collapse > li > a {
-  padding-top: 10px;
-  padding-bottom: 10px;
-  line-height: 18px;
-}
-.navbar-nav-no-collapse > li > .dropdown-menu {
-  margin-top: 0;
-  border-top-right-radius: 0;
-  border-top-left-radius: 0;
-}
+
 .navbar-nav-no-collapse {
   float: left;
   margin: 0;
+
+  > li {
+    float: left;
+  }
+
+  > li > a {
+    padding-top: 16px;
+    padding-bottom: 16px;
+  }
 }
-.navbar-nav-no-collapse > li {
-  float: left;
+
+.navbar-default {
+  .navbar-nav-no-collapse {
+    > li {
+      > a {
+        color: #777777;
+      }
+    }
+  }
 }
-.navbar-nav-no-collapse > li > a {
-  padding-top: 16px;
-  padding-bottom: 16px;
-}
-.navbar-default .navbar-nav-no-collapse > li > a {
-  color: #777777;
-}
+
 .navbar-default .navbar-nav-no-collapse > li > a:hover,
 .navbar-default .navbar-nav-no-collapse > li > a:focus {
   color: #333333;

--- a/src/css/bbgm.scss
+++ b/src/css/bbgm.scss
@@ -76,74 +76,93 @@ footer {
 
 .navbar-default {
   .navbar-nav-no-collapse {
-    > li {
-      > a {
-        color: #777777;
+    > li > a {
+      color: #777777;
+
+      &:hover,
+      &:focus {
+        color: #333333;
+        background-color: transparent;
+      }
+    }
+
+    > .active > a {
+      &,
+      &:hover,
+      &:focus {
+        color: #555555;
+        background-color: #e7e7e7;
+      }
+    }
+
+    > .disabled > a {
+      &,
+      &:hover,
+      &:focus {
+        color: #cccccc;
+        background-color: transparent;
+      }
+    }
+
+    > .dropdown > a {
+      &:hover .caret,
+      &:focus .caret {
+        border-top-color: #333333;
+        border-bottom-color: #333333;
+      }
+
+      .caret {
+        border-top-color: #777777;
+        border-bottom-color: #777777;
+      }
+    }
+
+    > .open > a {
+      &,
+      &:hover,
+      &:focus {
+        background-color: #e7e7e7;
+        color: #555555;
+      }
+    }
+
+    > .open > a {
+      .caret,
+      &:hover .caret,
+      &:focus .caret {
+        border-top-color: #555555;
+        border-bottom-color: #555555;
       }
     }
   }
 }
 
-.navbar-default .navbar-nav-no-collapse > li > a:hover,
-.navbar-default .navbar-nav-no-collapse > li > a:focus {
-  color: #333333;
-  background-color: transparent;
-}
-.navbar-default .navbar-nav-no-collapse > .active > a,
-.navbar-default .navbar-nav-no-collapse > .active > a:hover,
-.navbar-default .navbar-nav-no-collapse > .active > a:focus {
-  color: #555555;
-  background-color: #e7e7e7;
-}
-.navbar-default .navbar-nav-no-collapse > .disabled > a,
-.navbar-default .navbar-nav-no-collapse > .disabled > a:hover,
-.navbar-default .navbar-nav-no-collapse > .disabled > a:focus {
-  color: #cccccc;
-  background-color: transparent;
-}
-.navbar-default .navbar-nav-no-collapse > .dropdown > a:hover .caret,
-.navbar-default .navbar-nav-no-collapse > .dropdown > a:focus .caret {
-  border-top-color: #333333;
-  border-bottom-color: #333333;
-}
-.navbar-default .navbar-nav-no-collapse > .open > a,
-.navbar-default .navbar-nav-no-collapse > .open > a:hover,
-.navbar-default .navbar-nav-no-collapse > .open > a:focus {
-  background-color: #e7e7e7;
-  color: #555555;
-}
-.navbar-default .navbar-nav-no-collapse > .open > a .caret,
-.navbar-default .navbar-nav-no-collapse > .open > a:hover .caret,
-.navbar-default .navbar-nav-no-collapse > .open > a:focus .caret {
-  border-top-color: #555555;
-  border-bottom-color: #555555;
-}
-.navbar-default .navbar-nav-no-collapse > .dropdown > a .caret {
-  border-top-color: #777777;
-  border-bottom-color: #777777;
-}
-
 .god-mode {
   background-color: #563d7c !important;
   color: #fff !important;
+
+  &:hover,
+  &:focus {
+    background-color: #4a356b !important;
+  }
 }
-.god-mode:hover, .god-mode:focus {
-  background-color: #4a356b !important;
-}
+
 .god-mode-text {
   padding: 0 3px;
 }
 
-/* For the user/login widget */
+// For the user/login widget
 .user-menu {
   display: block;
   padding: 16px 15px;
-  margin-right: -15px; /* No right margin, like navbar-brand's left margin */
+  margin-right: -15px; // No right margin, like navbar-brand's left margin
+
+  &:hover {
+    text-decoration: none;
+  }
 }
-.user-menu:hover {
-  text-decoration: none;
-}
-/* http://stackoverflow.com/a/20839087/786644 */
+
+// http://stackoverflow.com/a/20839087/786644
 .navbar-link .visible-lg {
     display: none !important;
 }
@@ -162,68 +181,83 @@ footer {
 #play-button-link {
   color: #fff;
   background-color: #5cb85c;
-}
-#play-button-link:hover, #play-button-link:focus {
-  background-color: #47a447;
-}
-#play-button-link b.caret {
-  border-top-color: #fff;
+
+  &:hover,
+  &:focus {
+    background-color: #47a447;
+  }
+
+  b.caret {
+    border-top-color: #fff;
+  }
 }
 
 // This is for keyboard shortcuts in dropdowns
 .dropdown-menu > li > a {
   position: relative;
   padding-right: 70px;
-}
-.dropdown-menu > li > a > span.kbd {
-  position: absolute;
-  right: 20px;
-  top: 3px;
-}
-.dropdown-menu > li > a:hover > .text-muted {
-  color: #ccc;
+
+  > span.kbd {
+    position: absolute;
+    right: 20px;
+    top: 3px;
+  }
+
+  &:hover > .text-muted {
+    color: #ccc;
+  }
 }
 
 ul.dashboard-boxes {
   list-style: none;
   margin: 0 -1em 0 0;
   padding: 0;
-}
-ul.dashboard-boxes li {
-  float: left;
-  margin: 1em 1em 0 0;
-  position: relative;
-  overflow: hidden;
-}
-ul.dashboard-boxes li strong {
-  white-space: nowrap;
-}
-ul.dashboard-boxes li a.league {
-  display: block;
-  height: 60px;
-  padding: 2px 8px 6px 8px;
-  text-align: left;
-  width: 151px;
-}
-ul.dashboard-boxes li a.league:hover {
-  color: #000;
-}
-ul.dashboard-boxes li form.delete button {
-  border-radius: 0 4px 0 4px;
-  position: absolute;
-  top: 0px;
-  right: 5px;
-}
-ul.dashboard-boxes li.dashboard-box-new a {
-  color: #fff;
-}
-ul.dashboard-boxes li.dashboard-box-new a:hover {
-  color: #fff;
-}
-ul.dashboard-boxes li.dashboard-box-new h2 {
-  font-size: 20px;
-  line-height: 26px;
-  margin-top: 1px;
+
+  li {
+    float: left;
+    margin: 1em 1em 0 0;
+    position: relative;
+    overflow: hidden;
+
+    strong {
+      white-space: nowrap;
+    }
+
+    a.league {
+      display: block;
+      height: 60px;
+      padding: 2px 8px 6px 8px;
+      text-align: left;
+      width: 151px;
+
+      &:hover {
+        color: #000;
+      }
+    }
+
+    form.delete button {
+      border-radius: 0 4px 0 4px;
+      position: absolute;
+      top: 0px;
+      right: 5px;
+    }
+
+    &.dashboard-box-new {
+      a {
+        color: #fff;
+
+        &:hover {
+          color: #fff;
+        }
+      }
+
+      h2 {
+        font-size: 20px;
+        line-height: 26px;
+        margin-top: 1px;
+      }
+    }
+  }
 }
 
 .negotiation-team-years {
@@ -239,8 +273,7 @@ ul.dashboard-boxes li.dashboard-box-new h2 {
   .row-offcanvas {
     position: relative;
   }
-  .row-offcanvas-right
-  .sidebar-offcanvas {
+  .row-offcanvas-right .sidebar-offcanvas {
     right: -100%;
   }
   .sidebar-offcanvas {
@@ -253,8 +286,7 @@ ul.dashboard-boxes li.dashboard-box-new h2 {
   .row-offcanvas-force {
     position: relative;
   }
-  .row-offcanvas-right-force
-  .sidebar-offcanvas-force {
+  .row-offcanvas-right-force .sidebar-offcanvas-force {
     right: -100%;
   }
   .sidebar-offcanvas-force {
@@ -273,14 +305,18 @@ table {
   white-space: nowrap;
 }
 
-.table-bordered tbody tr.separator td {
-  border-bottom: 1px solid #888;
-}
-.table-bordered thead tr:last-child th {
-  border-bottom: 1px solid #888;
-}
-.table-bordered tfoot tr:first-child th {
-  border-top: 1px solid #888;
+.table-bordered {
+  tbody tr.separator td {
+    border-bottom: 1px solid #888;
+  }
+
+  thead tr:last-child th {
+    border-bottom: 1px solid #888;
+  }
+
+  tfoot tr:first-child th {
+    border-top: 1px solid #888;
+  }
 }
 
 .roster-handle {
@@ -296,19 +332,22 @@ table {
   color: #5bc0de;
 }
 
-#game-log-list tbody td {
-  padding: 0;
+#game-log-list {
+  tbody td {
+    padding: 0;
+  }
+
+  td a {
+    color: #3a87ad;
+    display: block;
+    // Expand to encompass normal td padding, which was set to 0 here above.
+    padding: 4px 5px 4px 5px;
+    text-decoration: none;
+  }
 }
 
-#game-log-list td a {
-  color: #3a87ad;
-  display: block;
-  // Expand to encompass normal td padding, which was set to 0 here above.
-  padding: 4px 5px 4px 5px;
-  text-decoration: none;
-}
-
-#game-log-list tbody tr:hover td, #messages tbody tr:hover td {
+#game-log-list tbody tr:hover td,
+#messages tbody tr:hover td {
   background-color: #d9edf7;
   border-color: #bce8f1;
   text-decoration: none;
@@ -379,10 +418,10 @@ table {
 
 #trade-summary {
   background-color: #fff;
-}
 
-#trade-summary form {
-  margin-bottom: 5px;
+  form {
+    margin-bottom: 5px;
+  }
 }
 
 .select-team {
@@ -441,36 +480,44 @@ table {
 }
 
 // These colors are duplicated from Roster.js
-.pt-modifier-select option[value="1"] {
-  background-color: #ccc;
-}
-.pt-modifier-select option[value="1.75"] {
-  background-color: #070;
-  color: #fff;
-}
-.pt-modifier-select option[value="1.25"] {
-  background-color: #0f0;
-}
-.pt-modifier-select option[value="0.75"] {
-  background-color: #ff0;
-}
-.pt-modifier-select option[value="0"] {
-  background-color: #a00;
-  color: #fff;
+.pt-modifier-select {
+  option[value="1"] {
+    background-color: #ccc;
+  }
+
+  option[value="1.75"] {
+    background-color: #070;
+    color: #fff;
+  }
+
+  option[value="1.25"] {
+    background-color: #0f0;
+  }
+
+  option[value="0.75"] {
+    background-color: #ff0;
+  }
+
+  option[value="0"] {
+    background-color: #a00;
+    color: #fff;
+  }
 }
 
 .achievements {
   margin: -4px;
-}
-.achievements .list-group-item {
-  border-radius: 0;
-  border: 0;
-  padding: 0;
-}
-.achievements .list-group-item div {
-  border-radius: 4px;
-  margin: 4px;
-  padding: 10px 15px;
+
+  .list-group-item {
+    border-radius: 0;
+    border: 0;
+    padding: 0;
+
+    div {
+      border-radius: 4px;
+      margin: 4px;
+      padding: 10px 15px;
+    }
+  }
 }
 
 .bar-graph-small {
@@ -501,18 +548,19 @@ table {
 .popover-content {
   font-size: 13px;
   font-weight: normal;
-}
 
-.popover-content p:last-child {
-  margin-bottom: 0;
+  p:last-child {
+    margin-bottom: 0;
+  }
 }
 
 // Stupid fix for popover on first run
 .popover-play {
   width: 276px;
-}
-.popover-play .popover-title {
-  background-color: #d0e9c6;
+
+  .popover-title {
+    background-color: #d0e9c6;
+  }
 }
 
 .finances-settings-label {
@@ -545,39 +593,45 @@ table {
 
 .trading-block-offer {
   margin-bottom: 2em;
-}
 
-.trading-block-offer h2 {
-  float: left;
-  margin-right: 0.5em;
+  h2 {
+    float: left;
+    margin-right: 0.5em;
+  }
 }
 
 #messages {
   table-layout: fixed;
   width: 100%;
+
+  td {
+    padding: 0;
+
+    a {
+      color: #333333;
+      display: block;
+      padding: 4px 5px 4px 5px;
+      text-decoration: none;
+    }
+  }
+
+  .year {
+    width: 40px;
+  }
+
+  .from {
+    width: 130px;
+  }
+
+  .text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    width: auto;
+  }
 }
-#messages td {
-  padding: 0;
-}
-#messages .year {
-  width: 40px;
-}
-#messages .from {
-  width: 130px;
-}
-#messages .text {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  width: auto;
-}
+
 .unread {
   font-weight: bold;
-}
-#messages td a {
-  color: #333333;
-  display: block;
-  padding: 4px 5px 4px 5px;
-  text-decoration: none;
 }
 
 .new_window {
@@ -597,16 +651,21 @@ table {
   margin-top: 20px;
   padding-bottom: 2px;
   padding-top: 12px;
+
+  button {
+    margin-top: -4px;
+  }
 }
-.alert-top button {
-  margin-top: -4px;
-}
-.alert-changes h4 {
-  margin-top: 0;
-}
-.alert-changes ul {
-  margin-bottom: 9px;
-  padding-left: 18px;
+
+.alert-changes {
+  h4 {
+    margin-top: 0;
+  }
+
+  ul {
+    margin-bottom: 9px;
+    padding-left: 18px;
+  }
 }
 
 .strong {
@@ -635,11 +694,13 @@ tr.warning > td {
   .affix-bottom {
     width: 213px;
   }
+
   .affix {
     // Undo the static from mobile first approach
     position: fixed;
     top: 60px;
   }
+
   .affix-bottom {
     // Undo the static from mobile first approach
     position: absolute;
@@ -670,24 +731,31 @@ tr.warning > td {
   padding: 5px 20px;
   text-transform: uppercase;
 }
-.bs-sidebar .nav > li > a {
-  display: block;
-  color: #333;
-  padding: 5px 20px;
-}
-.bs-sidebar .nav > li > a:hover,
-.bs-sidebar .nav > li > a:focus {
-  text-decoration: none;
-  background-color: #e0e0e0;
-  color: #333;
-}
-.bs-sidebar .nav > .active > a,
-.bs-sidebar .nav > .active:hover > a,
-.bs-sidebar .nav > .active:focus > a {
-  background-color: transparent;
-  border-right: 4px solid #428bca;
-  color: #333;
-  font-weight: bold;
+
+.bs-sidebar {
+  .nav {
+    > li > a {
+      display: block;
+      color: #333;
+      padding: 5px 20px;
+
+      &:hover,
+      &:focus {
+        text-decoration: none;
+        background-color: #e0e0e0;
+        color: #333;
+      }
+    }
+
+    > .active > a,
+    > .active:hover > a,
+    > .active:focus > a {
+      background-color: transparent;
+      border-right: 4px solid #428bca;
+      color: #333;
+      font-weight: bold;
+    }
+  }
 }
 
 #multi-team-menu {


### PR DESCRIPTION
I've finished converting the file.

I didn't change any of the actual functionality. Of course, I simplified rules by nesting them when necessary. I also converted all block comments to single-line comments so that they don't appear in the output file, as per Sass convention.

The output of this converted file is functionally the same as the original one. This can be verified by running the command `sass src/css/bbgm.scss` on both the original Sass file (before conversion work began) and afterward, and compare the two resulting .css files. Only whitespace differences and comments appear.

Fixes #154.