### PR TITLE
Bold output if it's a championship.

### DIFF
--- a/src/js/util/helpers.js
+++ b/src/js/util/helpers.js
@@ -946,6 +946,11 @@ function recordAndPlayoffs(abbrev, season, won, lost, playoffRoundsWon, option) 
         output += `, <a href="${leagueUrl(["playoffs", season])}">${extraText}</a>`;
     }
 
+    // Bold the output if this is a championship.
+    if (playoffRoundsWon === g.numPlayoffRounds) {
+        output = `<strong>${output}</strong>`;
+    }
+
     return output;
 }
 


### PR DESCRIPTION
Closes #137 

It's supposed to be a huge achievement when we win a championship (especially when I play on the hardest team and only win one every few decades), so it's definitely nice to highlight these in some way so I know when I won them, how long ago that was, etc.