### PR TITLE
On League Dashboard, show games remaining and percentage of season completed.

### DIFF
--- a/src/js/views/views/LeagueDashboard.js
+++ b/src/js/views/views/LeagueDashboard.js
@@ -8,9 +8,15 @@ const {NewWindowLink, PlayerNameLabels, PlayoffMatchup, RatingWithChange} = requ
 const LeagueDashboard = ({abbrev, ast, astRank, att, cash, completed = [], confTeams = [], leagueLeaders = {ast: {}, pts: {}, trb: {}}, lost, messages = [], name, oppPts, oppPtsRank, payroll, playoffRoundsWon, playoffsByConference, profit, pts, ptsRank, rank, region, revenue, salaryCap, season, series, seriesTitle, showPlayoffSeries, starters = [], teamLeaders = {ast: {}, pts: {}, trb: {}}, trb, trbRank, upcoming = [], won}) => {
     bbgmViewReact.title('Dashboard');
 
+    // Show the remaining number of games, only for the regular season.
     const gamesPlayed = won + lost;
     const gamesRemaining = g.numGames - gamesPlayed;
     const percentComplete = gamesPlayed / gamesRemaining;
+
+    let gamesRemainingTag = null;
+    if (g.phase === g.PHASE.REGULAR_SEASON) {
+        gamesRemainingTag = <p>{gamesRemaining} games remaining ({(percentComplete * 100).toFixed(1)}% complete)</p>;
+    }
 
     return <div>
         <h1>{region} {name} Dashboard <NewWindowLink /></h1>
@@ -120,7 +126,7 @@ const LeagueDashboard = ({abbrev, ast, astRank, att, cash, completed = [], confT
                         :
                             <div>
                                 <h3>Upcoming Games</h3>
-                                <p>{gamesRemaining} games remaining ({(percentComplete * 100).toFixed(1)}% complete)</p>
+                                {gamesRemainingTag}
                                 <ul className="list-group" style={{marginBottom: '6px'}}>
                                     {upcoming.map(game => <li key={game.gid} className="list-group-item schedule-row">
                                         <a href={helpers.leagueUrl(['roster', game.teams[0].abbrev])}>{game.teams[0].region}</a>

--- a/src/js/views/views/LeagueDashboard.js
+++ b/src/js/views/views/LeagueDashboard.js
@@ -120,7 +120,7 @@ const LeagueDashboard = ({abbrev, ast, astRank, att, cash, completed = [], confT
                         :
                             <div>
                                 <h3>Upcoming Games</h3>
-                                <div>{gamesRemaining} games remaining ({(percentComplete * 100).toFixed(1)}% complete)</div>
+                                <p>{gamesRemaining} games remaining ({(percentComplete * 100).toFixed(1)}% complete)</p>
                                 <ul className="list-group" style={{marginBottom: '6px'}}>
                                     {upcoming.map(game => <li key={game.gid} className="list-group-item schedule-row">
                                         <a href={helpers.leagueUrl(['roster', game.teams[0].abbrev])}>{game.teams[0].region}</a>

--- a/src/js/views/views/LeagueDashboard.js
+++ b/src/js/views/views/LeagueDashboard.js
@@ -8,6 +8,10 @@ const {NewWindowLink, PlayerNameLabels, PlayoffMatchup, RatingWithChange} = requ
 const LeagueDashboard = ({abbrev, ast, astRank, att, cash, completed = [], confTeams = [], leagueLeaders = {ast: {}, pts: {}, trb: {}}, lost, messages = [], name, oppPts, oppPtsRank, payroll, playoffRoundsWon, playoffsByConference, profit, pts, ptsRank, rank, region, revenue, salaryCap, season, series, seriesTitle, showPlayoffSeries, starters = [], teamLeaders = {ast: {}, pts: {}, trb: {}}, trb, trbRank, upcoming = [], won}) => {
     bbgmViewReact.title('Dashboard');
 
+    const gamesPlayed = won + lost;
+    const gamesRemaining = g.numGames - gamesPlayed;
+    const percentComplete = gamesPlayed / gamesRemaining;
+
     return <div>
         <h1>{region} {name} Dashboard <NewWindowLink /></h1>
 
@@ -116,6 +120,7 @@ const LeagueDashboard = ({abbrev, ast, astRank, att, cash, completed = [], confT
                         :
                             <div>
                                 <h3>Upcoming Games</h3>
+                                <div>{gamesRemaining} games remaining ({(percentComplete * 100).toFixed(1)}% complete)</div>
                                 <ul className="list-group" style={{marginBottom: '6px'}}>
                                     {upcoming.map(game => <li key={game.gid} className="list-group-item schedule-row">
                                         <a href={helpers.leagueUrl(['roster', game.teams[0].abbrev])}>{game.teams[0].region}</a>


### PR DESCRIPTION
Closes #139 

Let me know if I did it right or not. The final result looks good though. I originally had no decimal points in the percentage, but added it after seeing the number occasionally increase by one percent or two percent, which would look odd. This happens since the season is 82 games. 