### PR TITLE
Don't toggle rows if clicking on a link.

### DIFF
--- a/src/js/views/components/DataTable.js
+++ b/src/js/views/components/DataTable.js
@@ -49,7 +49,7 @@ const Header = ({cols, handleColClick, sortBys, superCols}) => {
 };
 
 const Row = clickable(({clicked, row, toggleClicked}) => {
-    return <tr className={classNames(row.classNames, {warning: clicked})} onClick={toggleClicked.bind(this)}>
+    return <tr className={classNames(row.classNames, {warning: clicked})} onClick={toggleClicked}>
         {row.data.map((value, i) => <td key={i}>{value}</td>)}
     </tr>;
 });

--- a/src/js/views/components/DataTable.js
+++ b/src/js/views/components/DataTable.js
@@ -49,7 +49,7 @@ const Header = ({cols, handleColClick, sortBys, superCols}) => {
 };
 
 const Row = clickable(({clicked, row, toggleClicked}) => {
-    return <tr className={classNames(row.classNames, {warning: clicked})} onClick={toggleClicked}>
+    return <tr className={classNames(row.classNames, {warning: clicked})} onClick={toggleClicked.bind(this)}>
         {row.data.map((value, i) => <td key={i}>{value}</td>)}
     </tr>;
 });

--- a/src/js/views/wrappers/clickable.js
+++ b/src/js/views/wrappers/clickable.js
@@ -9,10 +9,12 @@ module.exports = Component => {
             };
         }
 
-        toggleClicked(clickedNode) {
+        toggleClicked(event) {
+            const ignoredElements = ['A', 'BUTTON', 'SELECT'];
+
             // Don't toggle the row if a link was clicked.
-            if (clickedNode.target.nodeName === 'A') {
-                return true;
+            if (ignoredElements.indexOf(event.target.nodeName) > -1) {
+                return;
             }
 
             this.setState({
@@ -21,7 +23,7 @@ module.exports = Component => {
         }
 
         render() {
-            return <Component {...this.props} {...this.state} toggleClicked={clickedNode => this.toggleClicked(clickedNode)} />;
+            return <Component {...this.props} {...this.state} toggleClicked={event => this.toggleClicked(event)} />;
         }
     };
 };

--- a/src/js/views/wrappers/clickable.js
+++ b/src/js/views/wrappers/clickable.js
@@ -9,14 +9,19 @@ module.exports = Component => {
             };
         }
 
-        toggleClicked() {
+        toggleClicked(clickedNode) {
+            // Don't toggle the row if a link was clicked.
+            if (clickedNode.target.nodeName === 'A') {
+                return true;
+            }
+
             this.setState({
                 clicked: !this.state.clicked,
             });
         }
 
         render() {
-            return <Component {...this.props} {...this.state} toggleClicked={() => this.toggleClicked()} />;
+            return <Component {...this.props} {...this.state} toggleClicked={clickedNode => this.toggleClicked(clickedNode)} />;
         }
     };
 };


### PR DESCRIPTION
Closes #134 

When clicking on a link in a row, don't toggle the `warning` class on that row. This is particularly useful when opening a link in a new tab, because we aren't explicitly intending on toggling the `warning` class on that row.