### PR TITLE
Show team records on "Schedule" page

### DIFF
--- a/src/css/bbgm.scss
+++ b/src/css/bbgm.scss
@@ -418,6 +418,10 @@ table {
   font-size: 22px;
 }
 
+.schedule-extra {
+  font-size: 14px;
+}
+
 .table-nonfluid {
   width: auto;
 }

--- a/src/js/core/team.js
+++ b/src/js/core/team.js
@@ -408,7 +408,7 @@ function getPayrolls(tx) {
  * @param {Array.<string=>} options.stats List of team stats to include in output (e.g. fg, orb, ast, blk, ...).
  * @param {boolean=} options.totals Boolean representing whether to return total stats (true) or per-game averages (false); default is false.
  * @param {boolean=} options.playoffs Boolean representing whether to return playoff stats or not; default is false. Unlike player.filter, team.filter returns either playoff stats or regular season stats, never both.
- * @param {string=} options.sortby Sorting method. "winp" sorts by descending winning percentage. If undefined, then teams are returned in order of their team IDs (which is alphabetical, currently).
+ * @param {string=} options.sortBy Sorting method. "winp" sorts by descending winning percentage. If undefined, then teams are returned in order of their team IDs (which is alphabetical, currently).
  * @param {IDBTransaction|null=} options.ot An IndexedDB transaction on players, releasedPlayers, and teams; if null/undefined, then a new transaction will be used.
  * @return {Promise.(Object|Array.<Object>)} Filtered team object or array of filtered team objects, depending on the inputs.
  */

--- a/src/js/views/schedule.js
+++ b/src/js/views/schedule.js
@@ -13,7 +13,8 @@ function get(req) {
 
 async function updateUpcoming(inputs, updateEvents, state) {
     if (updateEvents.indexOf("dbChange") >= 0 || updateEvents.indexOf("firstRun") >= 0 || updateEvents.indexOf("gameSim") >= 0 || updateEvents.indexOf("newPhase") >= 0 || inputs.abbrev !== state.abbrev) {
-        const [schedule, teams] = await Promise.all([
+        // Get schedule and all teams.
+        const [schedule, teamsFiltered] = await Promise.all([
             season.getSchedule(),
             team.filter({
                 attrs: ['tid', 'abbrev'],
@@ -22,7 +23,14 @@ async function updateUpcoming(inputs, updateEvents, state) {
             }),
         ]);
 
-        const games = [];
+        // Create an object with team IDs as its keys.
+        const teamInfo = {};
+        for (const team of teamsFiltered) {
+            teamInfo[team.tid] = team;
+        }
+
+        // Loop through each game in the schedule.
+        const upcoming = [];
         for (const game of schedule) {
             if (inputs.tid === game.homeTid || inputs.tid === game.awayTid) {
                 const team0 = {
@@ -38,14 +46,15 @@ async function updateUpcoming(inputs, updateEvents, state) {
                     name: g.teamNamesCache[game.awayTid],
                 };
 
-                games.push({gid: game.gid, teams: [team1, team0]});
+                upcoming.push({gid: game.gid, teams: [team1, team0]});
             }
         }
 
         return {
             abbrev: inputs.abbrev,
             season: g.season,
-            upcoming: games,
+            teamInfo,
+            upcoming,
         };
     }
 }

--- a/src/js/views/schedule.js
+++ b/src/js/views/schedule.js
@@ -3,6 +3,7 @@ const season = require('../core/season');
 const bbgmViewReact = require('../util/bbgmViewReact');
 const helpers = require('../util/helpers');
 const Schedule = require('./views/Schedule');
+const team = require('../core/team');
 
 function get(req) {
     const inputs = {};
@@ -12,10 +13,17 @@ function get(req) {
 
 async function updateUpcoming(inputs, updateEvents, state) {
     if (updateEvents.indexOf("dbChange") >= 0 || updateEvents.indexOf("firstRun") >= 0 || updateEvents.indexOf("gameSim") >= 0 || updateEvents.indexOf("newPhase") >= 0 || inputs.abbrev !== state.abbrev) {
-        const schedule = await season.getSchedule();
+        const [schedule, teams] = await Promise.all([
+            season.getSchedule(),
+            team.filter({
+                attrs: ['tid', 'abbrev'],
+                seasonAttrs: ['won', 'lost', 'lastTen', 'streak'],
+                season: g.season,
+            }),
+        ]);
+
         const games = [];
-        for (let i = 0; i < schedule.length; i++) {
-            const game = schedule[i];
+        for (const game of schedule) {
             if (inputs.tid === game.homeTid || inputs.tid === game.awayTid) {
                 const team0 = {
                     tid: game.homeTid,

--- a/src/js/views/schedule.js
+++ b/src/js/views/schedule.js
@@ -17,8 +17,8 @@ async function updateUpcoming(inputs, updateEvents, state) {
         const [schedule, teamsFiltered] = await Promise.all([
             season.getSchedule(),
             team.filter({
-                attrs: ['tid', 'abbrev'],
-                seasonAttrs: ['won', 'lost', 'lastTen', 'streak'],
+                attrs: ['tid'],
+                seasonAttrs: ['won', 'lost'],
                 season: g.season,
             }),
         ]);

--- a/src/js/views/views/Schedule.js
+++ b/src/js/views/views/Schedule.js
@@ -37,9 +37,9 @@ module.exports = ({abbrev, completed, season, teamInfo, upcoming = []}) => {
                                     <a href={helpers.leagueUrl(['game_log', abbrev, season, gid])}>{score}{overtime}</a>
                                 </div>
                             </div>
-                            <a href={helpers.leagueUrl(['roster', teams[0].abbrev])}>{teams[0].region}</a> <span className="schedule-extra">({teamInfo[teams[0].tid].won}-{teamInfo[teams[0].tid].lost})</span>
+                            <a href={helpers.leagueUrl(['roster', teams[0].abbrev])}>{teams[0].region}</a>
                             <span className="schedule-at"> @ </span>
-                            <a href={helpers.leagueUrl(['roster', teams[1].abbrev])}>{teams[1].region}</a> <span className="schedule-extra">({teamInfo[teams[1].tid].won}-{teamInfo[teams[1].tid].lost})</span>
+                            <a href={helpers.leagueUrl(['roster', teams[1].abbrev])}>{teams[1].region}</a>
                         </li>;
                     })}
                 </ul>

--- a/src/js/views/views/Schedule.js
+++ b/src/js/views/views/Schedule.js
@@ -16,9 +16,9 @@ module.exports = ({abbrev, completed, season, teamInfo, upcoming = []}) => {
                 <h2>Upcoming Games</h2>
                 <ul className="list-group">
                     {upcoming.map(({gid, teams}) => <li className="list-group-item schedule-row" key={gid}>
-                        <a href={helpers.leagueUrl(['roster', teams[0].abbrev])}>{teams[0].region}</a> ({teamInfo[teams[0].tid].won}-{teamInfo[teams[0].tid].lost})
+                        <a href={helpers.leagueUrl(['roster', teams[0].abbrev])}>{teams[0].region}</a> <span className="schedule-extra">({teamInfo[teams[0].tid].won}-{teamInfo[teams[0].tid].lost})</span>
                         <span className="schedule-at"> @ </span>
-                        <a href={helpers.leagueUrl(['roster', teams[1].abbrev])}>{teams[1].region}</a> ({teamInfo[teams[1].tid].won}-{teamInfo[teams[1].tid].lost})
+                        <a href={helpers.leagueUrl(['roster', teams[1].abbrev])}>{teams[1].region}</a> <span className="schedule-extra">({teamInfo[teams[1].tid].won}-{teamInfo[teams[1].tid].lost})</span>
                     </li>)}
                 </ul>
             </div>
@@ -37,9 +37,9 @@ module.exports = ({abbrev, completed, season, teamInfo, upcoming = []}) => {
                                     <a href={helpers.leagueUrl(['game_log', abbrev, season, gid])}>{score}{overtime}</a>
                                 </div>
                             </div>
-                            <a href={helpers.leagueUrl(['roster', teams[0].abbrev])}>{teams[0].region}</a> ({teamInfo[teams[0].tid].won}-{teamInfo[teams[0].tid].lost})
+                            <a href={helpers.leagueUrl(['roster', teams[0].abbrev])}>{teams[0].region}</a> <span className="schedule-extra">({teamInfo[teams[0].tid].won}-{teamInfo[teams[0].tid].lost})</span>
                             <span className="schedule-at"> @ </span>
-                            <a href={helpers.leagueUrl(['roster', teams[1].abbrev])}>{teams[1].region}</a> ({teamInfo[teams[1].tid].won}-{teamInfo[teams[1].tid].lost})
+                            <a href={helpers.leagueUrl(['roster', teams[1].abbrev])}>{teams[1].region}</a> <span className="schedule-extra">({teamInfo[teams[1].tid].won}-{teamInfo[teams[1].tid].lost})</span>
                         </li>;
                     })}
                 </ul>

--- a/src/js/views/views/Schedule.js
+++ b/src/js/views/views/Schedule.js
@@ -4,7 +4,7 @@ const bbgmViewReact = require('../../util/bbgmViewReact');
 const helpers = require('../../util/helpers');
 const {Dropdown, NewWindowLink} = require('../components/index');
 
-module.exports = ({abbrev, completed, season, upcoming = []}) => {
+module.exports = ({abbrev, completed, season, teamInfo, upcoming = []}) => {
     bbgmViewReact.title('Schedule');
 
     return <div>
@@ -16,9 +16,9 @@ module.exports = ({abbrev, completed, season, upcoming = []}) => {
                 <h2>Upcoming Games</h2>
                 <ul className="list-group">
                     {upcoming.map(({gid, teams}) => <li className="list-group-item schedule-row" key={gid}>
-                        <a href={helpers.leagueUrl(['roster', teams[0].abbrev])}>{teams[0].region}</a>
+                        <a href={helpers.leagueUrl(['roster', teams[0].abbrev])}>{teams[0].region}</a> ({teamInfo[teams[0].tid].won}-{teamInfo[teams[0].tid].lost})
                         <span className="schedule-at"> @ </span>
-                        <a href={helpers.leagueUrl(['roster', teams[1].abbrev])}>{teams[1].region}</a>
+                        <a href={helpers.leagueUrl(['roster', teams[1].abbrev])}>{teams[1].region}</a> ({teamInfo[teams[1].tid].won}-{teamInfo[teams[1].tid].lost})
                     </li>)}
                 </ul>
             </div>

--- a/src/js/views/views/Schedule.js
+++ b/src/js/views/views/Schedule.js
@@ -37,9 +37,9 @@ module.exports = ({abbrev, completed, season, teamInfo, upcoming = []}) => {
                                     <a href={helpers.leagueUrl(['game_log', abbrev, season, gid])}>{score}{overtime}</a>
                                 </div>
                             </div>
-                            <a href={helpers.leagueUrl(['roster', teams[0].abbrev])}>{teams[0].region}</a>
+                            <a href={helpers.leagueUrl(['roster', teams[0].abbrev])}>{teams[0].region}</a> ({teamInfo[teams[0].tid].won}-{teamInfo[teams[0].tid].lost})
                             <span className="schedule-at"> @ </span>
-                            <a href={helpers.leagueUrl(['roster', teams[1].abbrev])}>{teams[1].region}</a>
+                            <a href={helpers.leagueUrl(['roster', teams[1].abbrev])}>{teams[1].region}</a> ({teamInfo[teams[1].tid].won}-{teamInfo[teams[1].tid].lost})
                         </li>;
                     })}
                 </ul>


### PR DESCRIPTION
Closes #138 

Shows team records for Upcoming and Completed Games, for all teams. Does not show records as of the "Completed" game. Will be done in the future.

I tried adding L10 and possibly streaks, but it seemed too cluttered. But at the very least, perhaps include L10, but make the font size smaller for the team records and L10.