### PR TITLE
PlayerStats: Change defaultSort to 'Min' desc.

### DIFF
--- a/src/js/views/views/PlayerStats.js
+++ b/src/js/views/views/PlayerStats.js
@@ -119,7 +119,8 @@ const PlayerStats = ({abbrev, season, statType, players = [], playoffs}) => {
 
         <DataTable
             cols={cols}
-            defaultSort={[27, 'desc']}
+            // 'Min'
+            defaultSort={[5, 'desc']}
             rows={rows}
             pagination={true}
             superCols={superCols}


### PR DESCRIPTION
On PlayerStats, change defaultSort from 'EWA' desc. to 'Min' desc., per BBRef, etc. 

EWA wouldn't be accurate in telling you your most impactful players if you recently traded for a good player, for instance, if that's the reason as to why it's being used for the default sort.

I think adding the tiny comment is useful too, as the index number itself doesn't mean anything at all just by looking at it.