### PR TITLE
Add "free cap space" to Team Finances

### DIFF
--- a/src/js/views/components/DataTable.js
+++ b/src/js/views/components/DataTable.js
@@ -347,10 +347,29 @@ class DataTable extends React.Component {
             </div>;
         }
 
+        // Table footer
         let tfoot = null;
         if (footer) {
+            let footers;
+
+            // There are multiple footers.
+            if (Array.isArray(footer[0])) {
+                footers = footer;
+            // There's only one footer.
+            } else {
+                footers = [footer];
+            }
+
+            // Footer rows
+            const footerRows = [];
+
+            for (const item of footers) {
+                const index = footers.indexOf(item);
+                footerRows.push(<tr key={index}>{item.map((value, i) => <th key={i}>{value}</th>)}</tr>);
+            }
+
             tfoot = <tfoot>
-                <tr>{footer.map((value, i) => <th key={i}>{value}</th>)}</tr>
+                {footerRows}
             </tfoot>;
         }
 

--- a/src/js/views/components/DataTable.js
+++ b/src/js/views/components/DataTable.js
@@ -365,7 +365,15 @@ class DataTable extends React.Component {
 
             for (const item of footers) {
                 const index = footers.indexOf(item);
-                footerRows.push(<tr key={index}>{item.map((value, i) => <th key={i}>{value}</th>)}</tr>);
+                const items = item.map((value, i) => {
+                    if (value.hasOwnProperty('value')) {
+                        return <th className={classNames(value.classNames)} key={i}>{value.value}</th>;
+                    }
+
+                    return <th key={i}>{value}</th>;
+                });
+
+                footerRows.push(<tr key={index}>{items}</tr>);
             }
 
             tfoot = <tfoot>

--- a/src/js/views/views/TeamFinances.js
+++ b/src/js/views/views/TeamFinances.js
@@ -191,14 +191,19 @@ const TeamFinances = ({abbrev, barData = {expenses: {salary: [], minTax: [], lux
                 watch={p.watch}
             >{p.firstName} {p.lastName}</PlayerNameLabels>,
         ];
+
+        // Loop through the salaries for the next five years for this player.
         for (let i = 0; i < 5; i++) {
             if (p.amounts[i]) {
-                data.push(helpers.formatCurrency(p.amounts[i], "M"));
+                const formattedAmount = helpers.formatCurrency(p.amounts[i], "M");
+
+                if (p.released) {
+                    data.push(<i>{formattedAmount}</i>);
+                } else {
+                    data.push(formattedAmount);
+                }
             } else {
                 data.push(null);
-            }
-            if (p.released) {
-                data[i + 1] = <i>{data[i + 1]}</i>;
             }
         }
 

--- a/src/js/views/views/TeamFinances.js
+++ b/src/js/views/views/TeamFinances.js
@@ -213,7 +213,20 @@ const TeamFinances = ({abbrev, barData = {expenses: {salary: [], minTax: [], lux
         };
     });
 
-    const footer = ['Totals'].concat(contractTotals.map(amount => helpers.formatCurrency(amount, 'M')));
+    function muteZeroAmount(amount) {
+        const formattedValue = helpers.formatCurrency(amount, 'M');
+
+        if (amount === 0) {
+            return {classNames: 'text-muted', value: formattedValue};
+        }
+
+        return formattedValue;
+    }
+
+    const footer = [
+        ['Totals'].concat(contractTotals.map(amount => muteZeroAmount(amount))),
+        ['Free cap space'].concat(contractTotals.map((amount) => muteZeroAmount(salaryCap - amount))),
+    ];
 
     return <div>
         <Dropdown view="team_finances" fields={["teams", "shows"]} values={[abbrev, show]} />


### PR DESCRIPTION
Closes #196 

- Add the ability to add multiple footers.
- Simplified the looping of the salaries for each player.
- Add the ability to add class names to footer cells, just like table body cells.
- Add free cap space footer to Team Finances page.
