### PR TITLE
add notification right before uploading to Imgur

### DIFF
--- a/src/js/views/components/NavBar.js
+++ b/src/js/views/components/NavBar.js
@@ -117,6 +117,15 @@ const handleScreenshotClick = e => {
             // Remove notifications
             contentEl.removeChild(notifications);
 
+            logEvent(null, {
+                type: 'screenshot',
+                text: `Uploading your screenshot to Imgur...`,
+                saveToDb: false,
+                showNotification: true,
+                persistent: false,
+                extraClass: 'notification-primary',
+            });
+
             try {
                 const data = await Promise.resolve($.ajax({
                     url: "https://imgur-apiv3.p.mashape.com/3/image",


### PR DESCRIPTION
This is one really tiny thing on taking/uploading screenshot. I noticed that when you click the Screenshot button from the top menu, there's a slight delay then a notification would appear and say it has been uploaded here. 

At first it kind of made me confused since there's a long delay between clicking that and seeing the notification, ended up making me spamming the screenshot button because I thought it wasn't working. Turns out it took quite a while to upload (I'm on a slow connection here, so...)

I thought having another non-persistent notification before uploading to Imgur would at least help with the confusion of the delay. 

Thoughts?