### PR TITLE
Add more highlight colors to Hall of Fame page

### DIFF
--- a/src/js/views/hallOfFame.js
+++ b/src/js/views/hallOfFame.js
@@ -25,21 +25,20 @@ async function updatePlayers(inputs, updateEvents) {
                 }
             }
 
-            players[i].bestStats = {
-                gp: 0,
-                min: 0,
-                per: 0,
-            };
+            players[i].bestStats = {};
+            let bestEWA = 0;
             players[i].teamSums = {};
             for (let j = 0; j < players[i].stats.length; j++) {
                 const tid = players[i].stats[j].tid;
-                if (players[i].stats[j].gp * players[i].stats[j].min * players[i].stats[j].per > players[i].bestStats.gp * players[i].bestStats.min * players[i].bestStats.per) {
+                const EWA = players[i].stats[j].ewa;
+                if (EWA > bestEWA) {
                     players[i].bestStats = players[i].stats[j];
+                    bestEWA = EWA;
                 }
                 if (players[i].teamSums.hasOwnProperty(tid)) {
-                    players[i].teamSums[tid] += players[i].stats[j].gp * players[i].stats[j].min * players[i].stats[j].per;
+                    players[i].teamSums[tid] += EWA;
                 } else {
-                    players[i].teamSums[tid] = players[i].stats[j].gp * players[i].stats[j].min * players[i].stats[j].per;
+                    players[i].teamSums[tid] = EWA;
                 }
             }
             players[i].legacyTid = parseInt(Object.keys(players[i].teamSums).reduce((teamA, teamB) => (players[i].teamSums[teamA] > players[i].teamSums[teamB] ? teamA : teamB)));

--- a/src/js/views/hallOfFame.js
+++ b/src/js/views/hallOfFame.js
@@ -32,14 +32,14 @@ async function updatePlayers(inputs, updateEvents) {
             };
             players[i].teamSums = {};
             for (let j = 0; j < players[i].stats.length; j++) {
-                const team = players[i].stats[j].tid;
+                const tid = players[i].stats[j].tid;
                 if (players[i].stats[j].gp * players[i].stats[j].min * players[i].stats[j].per > players[i].bestStats.gp * players[i].bestStats.min * players[i].bestStats.per) {
                     players[i].bestStats = players[i].stats[j];
                 }
-                if (players[i].teamSums.hasOwnProperty(team)) {
-                    players[i].teamSums[team] += players[i].stats[j].gp * players[i].stats[j].min * players[i].stats[j].per;
+                if (players[i].teamSums.hasOwnProperty(tid)) {
+                    players[i].teamSums[tid] += players[i].stats[j].gp * players[i].stats[j].min * players[i].stats[j].per;
                 } else {
-                    players[i].teamSums[team] = players[i].stats[j].gp * players[i].stats[j].min * players[i].stats[j].per;
+                    players[i].teamSums[tid] = players[i].stats[j].gp * players[i].stats[j].min * players[i].stats[j].per;
                 }
             }
             players[i].legacyTid = parseInt(Object.keys(players[i].teamSums).reduce((teamA, teamB) => (players[i].teamSums[teamA] > players[i].teamSums[teamB] ? teamA : teamB)));

--- a/src/js/views/hallOfFame.js
+++ b/src/js/views/hallOfFame.js
@@ -13,7 +13,7 @@ async function updatePlayers(inputs, updateEvents) {
         players = player.filter(players, {
             attrs: ["pid", "name", "draft", "retiredYear", "statsTids"],
             ratings: ["ovr", "pos"],
-            stats: ["season", "abbrev", "gp", "min", "trb", "ast", "pts", "per", "ewa"],
+            stats: ["season", "abbrev", "tid", "gp", "min", "trb", "ast", "pts", "per", "ewa"],
         });
 
         // This stuff isn't in player.filter because it's only used here.
@@ -30,11 +30,19 @@ async function updatePlayers(inputs, updateEvents) {
                 min: 0,
                 per: 0,
             };
+            players[i].teamSums = {};
             for (let j = 0; j < players[i].stats.length; j++) {
+                const team = players[i].stats[j].tid;
                 if (players[i].stats[j].gp * players[i].stats[j].min * players[i].stats[j].per > players[i].bestStats.gp * players[i].bestStats.min * players[i].bestStats.per) {
                     players[i].bestStats = players[i].stats[j];
                 }
+                if (players[i].teamSums.hasOwnProperty(team)) {
+                    players[i].teamSums[team] += players[i].stats[j].gp * players[i].stats[j].min * players[i].stats[j].per;
+                } else {
+                    players[i].teamSums[team] = players[i].stats[j].gp * players[i].stats[j].min * players[i].stats[j].per;
+                }
             }
+            players[i].legacyTid = parseInt(Object.keys(players[i].teamSums).reduce((teamA, teamB) => (players[i].teamSums[teamA] > players[i].teamSums[teamB] ? teamA : teamB)));
         }
 
         return {

--- a/src/js/views/hallOfFame.js
+++ b/src/js/views/hallOfFame.js
@@ -41,7 +41,7 @@ async function updatePlayers(inputs, updateEvents) {
                     players[i].teamSums[tid] = EWA;
                 }
             }
-            players[i].legacyTid = parseInt(Object.keys(players[i].teamSums).reduce((teamA, teamB) => (players[i].teamSums[teamA] > players[i].teamSums[teamB] ? teamA : teamB)));
+            players[i].legacyTid = parseInt(Object.keys(players[i].teamSums).reduce((teamA, teamB) => (players[i].teamSums[teamA] > players[i].teamSums[teamB] ? teamA : teamB)), 10);
         }
 
         return {

--- a/src/js/views/views/HallOfFame.js
+++ b/src/js/views/views/HallOfFame.js
@@ -49,8 +49,8 @@ const HallOfFame = ({players}) => {
             ],
             classNames: {
                 danger: p.legacyTid === g.userTid,
-                info: p.statsTids.includes(g.userTid) && p.statsTids[p.statsTids.length - 1] !== g.userTid,
-                success: p.statsTids[p.statsTids.length - 1] === g.userTid,
+                info: p.statsTids.slice(0, p.statsTids.length - 1).includes(g.userTid) && p.legacyTid !== g.userTid,
+                success: p.statsTids[p.statsTids.length - 1] === g.userTid && p.legacyTid !== g.userTid,
             },
         };
     });

--- a/src/js/views/views/HallOfFame.js
+++ b/src/js/views/views/HallOfFame.js
@@ -48,7 +48,9 @@ const HallOfFame = ({players}) => {
                 helpers.round(p.careerStats.ewa, 1),
             ],
             classNames: {
-                info: p.statsTids.includes(g.userTid),
+                danger: p.legacyTid === g.userTid,
+                info: p.statsTids.includes(g.userTid) && p.statsTids[p.statsTids.length - 1] !== g.userTid,
+                success: p.statsTids[p.statsTids.length - 1] === g.userTid,
             },
         };
     });

--- a/src/js/views/views/HallOfFame.js
+++ b/src/js/views/views/HallOfFame.js
@@ -58,7 +58,7 @@ const HallOfFame = ({players}) => {
     return <div>
         <h1>Hall of Fame <NewWindowLink /></h1>
 
-        <p>Players are eligible to be inducted into the Hall of Fame after they retire. The formula for inclusion is very similar to <a href="http://espn.go.com/nba/story/_/id/8736873/nba-experts-rebuild-springfield-hall-fame-espn-magazine">the method described in this article</a>. Hall of famers who played for your team are <span className="text-info">highlighted in blue</span>.</p>
+        <p>Players are eligible to be inducted into the Hall of Fame after they retire. The formula for inclusion is very similar to <a href="http://espn.go.com/nba/story/_/id/8736873/nba-experts-rebuild-springfield-hall-fame-espn-magazine">the method described in this article</a>. Hall of Famers who played for your team are <span className="text-info">highlighted in blue</span>. Hall of Famers who retired with your team are <span className="text-success">highlighted in green</span>. Hall of Famers who played most of their career with your team are <span className="text-danger">highlighted in red</span>.</p>
 
         <DataTable
             cols={cols}


### PR DESCRIPTION
In honor of the scrapped HoF PR... I'm making a new one! Hah, you thought it was dead!

This PR introduces two new colors in addition to the normal blue highlight.

* Blue maintains its meaning of "this player was on your team at least once" and uses the same includes() check, but is now the "catch-all" for when the following colors do not apply
* Green is used to highlight players who retired with your team
* Red is used to highlight players who earned a plurality of their career EWA with your team. I considered making this restriction "majority", and would like feedback on that. 

Example screenshot:

http://imgur.com/uF26kxT

