### PR TITLE
Enhance playoffs page, use logos in team tables

### DIFF
--- a/src/css/bbgm.scss
+++ b/src/css/bbgm.scss
@@ -832,3 +832,8 @@ label input {
 .dropdown-toggle {
   cursor: pointer;
 }
+
+img.losing-team {
+  -webkit-filter: grayscale(1);
+  filter: grayscale(1);
+}

--- a/src/css/bbgm.scss
+++ b/src/css/bbgm.scss
@@ -857,8 +857,7 @@ img.losing-team {
   height: 18px;
   border-radius: 50%;
   display: inline-block;
-  margin-left: 2px;
-  margin-right: 2px;
+  margin-right: 4px;
 
   img {
     width: 100%;

--- a/src/css/bbgm.scss
+++ b/src/css/bbgm.scss
@@ -834,6 +834,36 @@ label input {
 }
 
 img.losing-team {
-  -webkit-filter: grayscale(1);
   filter: grayscale(1);
+  transition: 2s ease-in-out;
+}
+
+.playoff-matchup-logo {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  display: inline-block;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    @extend .img-circle;
+  }
+}
+
+.table-logo {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: inline-block;
+  margin-left: 2px;
+  margin-right: 2px;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    @extend .img-circle;
+  }
 }

--- a/src/js/core/phase.js
+++ b/src/js/core/phase.js
@@ -168,7 +168,7 @@ async function newPhasePlayoffs(tx: BackboardTx) {
     // Set playoff matchups
     const teams = await team.filter({
         ot: tx,
-        attrs: ["tid", "cid"],
+        attrs: ["tid", "cid", "imgURL"],
         seasonAttrs: ["winp"],
         season: g.season,
         sortBy: "winp",

--- a/src/js/views/components/PlayoffJumbotron.js
+++ b/src/js/views/components/PlayoffJumbotron.js
@@ -1,0 +1,37 @@
+// @flow
+import React from 'react';
+import g from '../../globals';
+import * as helpers from '../../util/helpers';
+
+const PlayoffJumbotron = ({season, playoffRound, west, east}) => {
+    return <div className="jumbotron text-center">
+        <h2>{season} {playoffRound}</h2>
+        <div className="row">
+            <div className="col-xs-5">
+                <a href={helpers.leagueUrl(["roster", g.teamAbbrevsCache[west.tid], season])}>
+                    <img className={east.won === 4 && "losing-team"} src={west.imgURL} height="80" alt="" />
+                </a>
+                <h3 className={g.userTid === west.tid && "bg-info"}>{g.teamRegionsCache[west.tid]} {g.teamNamesCache[west.tid]} ({west.seed})</h3>
+                <h1>{west.won}</h1>
+            </div>
+            <div className="col-xs-2">
+                <h1>VS</h1>
+            </div>
+            <div className="col-xs-5">
+                <a href={helpers.leagueUrl(["roster", g.teamAbbrevsCache[east.tid], season])}>
+                    <img className={west.won === 4 && "losing-team"} src={east.imgURL} height="80" alt="" />
+                </a>
+                <h3 className={g.userTid === east.tid && "bg-info"}>{g.teamRegionsCache[east.tid]} {g.teamNamesCache[east.tid]} ({east.seed}) </h3>
+                <h1>{east.won}</h1>
+            </div>
+        </div>
+    </div>;
+};
+PlayoffJumbotron.propTypes = {
+    season: React.PropTypes.number,
+    playoffRound: React.PropTypes.any,
+    east: React.PropTypes.object,
+    west: React.PropTypes.object,
+};
+
+export default PlayoffJumbotron;

--- a/src/js/views/components/PlayoffMatchup.js
+++ b/src/js/views/components/PlayoffMatchup.js
@@ -24,17 +24,23 @@ const PlayoffMatchup = ({season, series}: {
     const homeWon = series.home.hasOwnProperty("won") && series.home.won === 4;
     const awayWon = series.away.hasOwnProperty("won") && series.away.won === 4;
 
-    const homeImg = `img-circle ${awayWon && "losing-team"}`;
-    const awayImg = `img-circle ${homeWon && "losing-team"}`;
+    const homeImg = `${awayWon && "losing-team" || ""}`;
+    const awayImg = `${homeWon && "losing-team" || ""}`;
 
     return <div>
         {series.home.imgURL && series.away.imgURL &&
-            <p>
+            <span>
                 <a href={helpers.leagueUrl(["roster", g.teamAbbrevsCache[series.home.tid], season])}>
-                    <img className={homeImg} height="36" width="36" src={series.home.imgURL} alt="" /></a> vs
-                <a href={helpers.leagueUrl(["roster", g.teamAbbrevsCache[series.away.tid], season])}>
-                    <img className={awayImg} height="36" width="36" src={series.away.imgURL} alt="" /></a>
-            </p>}
+                    <div className="playoff-matchup-logo">
+                        <img className={homeImg} src={series.home.imgURL} alt="" />
+                    </div>
+                </a> vs <a href={helpers.leagueUrl(["roster", g.teamAbbrevsCache[series.away.tid], season])}>
+                    <div className="playoff-matchup-logo">
+                        <img className={awayImg} src={series.away.imgURL} alt="" />
+                    </div>
+                </a>
+                <br />
+            </span>}
 
         <span className={series.home.tid === g.userTid ? 'bg-info' : ''} style={{fontWeight: homeWon ? 'bold' : 'normal'}}>
             {series.home.seed}. <a href={helpers.leagueUrl(["roster", g.teamAbbrevsCache[series.home.tid], season])}>{g.teamRegionsCache[series.home.tid]}</a>

--- a/src/js/views/components/PlayoffMatchup.js
+++ b/src/js/views/components/PlayoffMatchup.js
@@ -24,7 +24,18 @@ const PlayoffMatchup = ({season, series}: {
     const homeWon = series.home.hasOwnProperty("won") && series.home.won === 4;
     const awayWon = series.away.hasOwnProperty("won") && series.away.won === 4;
 
+    const homeImg = `img-circle ${awayWon && "losing-team"}`;
+    const awayImg = `img-circle ${homeWon && "losing-team"}`;
+
     return <div>
+        {series.home.imgURL && series.away.imgURL &&
+            <p>
+                <a href={helpers.leagueUrl(["roster", g.teamAbbrevsCache[series.home.tid], season])}>
+                    <img className={homeImg} height="36" width="36" src={series.home.imgURL} alt="" /></a> vs
+                <a href={helpers.leagueUrl(["roster", g.teamAbbrevsCache[series.away.tid], season])}>
+                    <img className={awayImg} height="36" width="36" src={series.away.imgURL} alt="" /></a>
+            </p>}
+
         <span className={series.home.tid === g.userTid ? 'bg-info' : ''} style={{fontWeight: homeWon ? 'bold' : 'normal'}}>
             {series.home.seed}. <a href={helpers.leagueUrl(["roster", g.teamAbbrevsCache[series.home.tid], season])}>{g.teamRegionsCache[series.home.tid]}</a>
             {series.home.hasOwnProperty("won") ? <span> {series.home.won}</span> : null }

--- a/src/js/views/components/index.js
+++ b/src/js/views/components/index.js
@@ -16,6 +16,7 @@ import NewWindowLink from './NewWindowLink';
 import PlayerNameLabels from './PlayerNameLabels';
 import PlayerPicture from './PlayerPicture';
 import PlayoffMatchup from './PlayoffMatchup';
+import PlayoffJumbotron from './PlayoffJumbotron';
 import RatingWithChange from './RatingWithChange';
 import RecordAndPlayoffs from './RecordAndPlayoffs';
 import SafeHtml from './SafeHtml';
@@ -41,6 +42,7 @@ export {
     PlayerNameLabels,
     PlayerPicture,
     PlayoffMatchup,
+    PlayoffJumbotron,
     RatingWithChange,
     RecordAndPlayoffs,
     SafeHtml,

--- a/src/js/views/historyAll.js
+++ b/src/js/views/historyAll.js
@@ -11,7 +11,7 @@ async function updateHistory(inputs, updateEvents) {
         const [awards, teams] = await Promise.all([
             g.dbl.awards.getAll(),
             team.filter({
-                attrs: ["tid", "abbrev", "region", "name"],
+                attrs: ["tid", "abbrev", "region", "name", "imgURL"],
                 seasonAttrs: ["season", "playoffRoundsWon", "won", "lost"],
             }),
         ]);
@@ -50,6 +50,7 @@ async function updateHistory(inputs, updateEvents) {
                         name: t.name,
                         won: t.seasons[j].won,
                         lost: t.seasons[j].lost,
+                        imgURL: t.imgURL,
                     };
                 } else if (t.seasons[j].playoffRoundsWon === g.numPlayoffRounds - 1) {
                     seasons[i].runnerUp = {
@@ -59,6 +60,7 @@ async function updateHistory(inputs, updateEvents) {
                         name: t.name,
                         won: t.seasons[j].won,
                         lost: t.seasons[j].lost,
+                        imgURL: t.imgURL,
                     };
                 }
             }

--- a/src/js/views/leagueDashboard.js
+++ b/src/js/views/leagueDashboard.js
@@ -278,7 +278,7 @@ async function updatePlayoffs(inputs, updateEvents) {
 async function updateStandings(inputs, updateEvents) {
     if (updateEvents.includes('dbChange') || updateEvents.includes('firstRun') || updateEvents.includes('gameSim')) {
         const teams = await team.filter({
-            attrs: ["tid", "cid", "abbrev", "region"],
+            attrs: ["tid", "cid", "abbrev", "region", "imgURL"],
             seasonAttrs: ["won", "lost", "winp"],
             season: g.season,
             sortBy: ["winp", "-lost", "won"],

--- a/src/js/views/leagueFinances.js
+++ b/src/js/views/leagueFinances.js
@@ -15,7 +15,7 @@ function get(ctx) {
 async function updateLeagueFinances(inputs, updateEvents, state) {
     if (updateEvents.includes('dbChange') || updateEvents.includes('firstRun') || inputs.season !== state.season || inputs.season === g.season) {
         const teams = await team.filter({
-            attrs: ["tid", "abbrev", "region", "name"],
+            attrs: ["tid", "abbrev", "region", "name", "imgURL"],
             seasonAttrs: ["att", "revenue", "profit", "cash", "payroll", "salaryPaid"],
             season: inputs.season,
         });

--- a/src/js/views/playoffs.js
+++ b/src/js/views/playoffs.js
@@ -21,7 +21,7 @@ async function updatePlayoffs(inputs, updateEvents, state) {
         // If in the current season and before playoffs started, display projected matchups
         if (inputs.season === g.season && g.phase < g.PHASE.PLAYOFFS) {
             const teams = await team.filter({
-                attrs: ["tid", "cid", "abbrev", "name"],
+                attrs: ["tid", "cid", "abbrev", "name", "imgURL"],
                 seasonAttrs: ["winp"],
                 season: inputs.season,
                 sortBy: ["winp", "-lost", "won"],

--- a/src/js/views/powerRankings.js
+++ b/src/js/views/powerRankings.js
@@ -11,7 +11,7 @@ async function updatePowerRankings(inputs, updateEvents) {
     if (updateEvents.includes('firstRun') || updateEvents.includes('dbChange') || updateEvents.includes('gameSim')) {
         const [teams, players] = await Promise.all([
             team.filter({
-                attrs: ["tid", "abbrev", "region", "name"],
+                attrs: ["tid", "abbrev", "region", "name", "imgURL"],
                 seasonAttrs: ["won", "lost", "lastTen"],
                 stats: ["gp", "pts", "oppPts", "diff"],
                 season: g.season,

--- a/src/js/views/schedule.js
+++ b/src/js/views/schedule.js
@@ -18,7 +18,7 @@ async function updateUpcoming(inputs, updateEvents, state) {
         const [schedule, teamsFiltered] = await Promise.all([
             season.getSchedule(),
             team.filter({
-                attrs: ['tid'],
+                attrs: ['tid', 'imgURL'],
                 seasonAttrs: ['won', 'lost'],
                 season: g.season,
             }),

--- a/src/js/views/standings.js
+++ b/src/js/views/standings.js
@@ -15,7 +15,7 @@ function get(ctx) {
 async function updateStandings(inputs, updateEvents, state) {
     if (updateEvents.includes('dbChange') || (inputs.season === g.season && updateEvents.includes('gameSim')) || inputs.season !== state.season) {
         const teams = await team.filter({
-            attrs: ["tid", "cid", "did", "abbrev", "region", "name"],
+            attrs: ["tid", "cid", "did", "abbrev", "region", "name", "imgURL"],
             seasonAttrs: ["won", "lost", "winp", "wonHome", "lostHome", "wonAway", "lostAway", "wonDiv", "lostDiv", "wonConf", "lostConf", "lastTen", "streak"],
             season: inputs.season,
             sortBy: ["winp", "-lost", "won"],

--- a/src/js/views/views/HistoryAll.js
+++ b/src/js/views/views/HistoryAll.js
@@ -31,7 +31,8 @@ const teamName = (t, season) => {
         return <span>
             <span className="table-logo">
                 <img src={t.imgURL} alt="" />
-            </span> <a href={helpers.leagueUrl(["roster", t.abbrev, season])}>{t.region}</a> ({t.won}-{t.lost})
+            </span>
+            <a href={helpers.leagueUrl(["roster", t.abbrev, season])}>{t.region}</a> ({t.won}-{t.lost})
         </span>;
     }
 

--- a/src/js/views/views/HistoryAll.js
+++ b/src/js/views/views/HistoryAll.js
@@ -29,7 +29,9 @@ const awardName = (award, season) => {
 const teamName = (t, season) => {
     if (t) {
         return <span>
-            <a href={helpers.leagueUrl(["roster", t.abbrev, season])}>{t.region}</a> ({t.won}-{t.lost})
+            <span className="table-logo">
+                <img src={t.imgURL} alt="" />
+            </span> <a href={helpers.leagueUrl(["roster", t.abbrev, season])}>{t.region}</a> ({t.won}-{t.lost})
         </span>;
     }
 

--- a/src/js/views/views/LeagueDashboard.js
+++ b/src/js/views/views/LeagueDashboard.js
@@ -33,7 +33,10 @@ const LeagueDashboard = ({abbrev, ast, astRank, att, cash, completed, confTeams,
                             <tbody>
                                 {confTeams.map((t, i) => {
                                     return <tr key={t.tid} className={classNames({separator: i === 7 && playoffsByConference, info: t.tid === g.userTid})}>
-                                        <td>{t.rank}. <a href={helpers.leagueUrl(['roster', t.abbrev])}>{t.region}</a></td>
+                                        <td>{t.rank}.
+                                            <span className="table-logo"><img src={t.imgURL} alt="" /></span>
+                                            <a href={helpers.leagueUrl(['roster', t.abbrev])}>{t.region}</a>
+                                        </td>
                                         <td style={{textAlign: 'right'}}>{t.gb}</td>
                                     </tr>;
                                 })}

--- a/src/js/views/views/LeagueFinances.js
+++ b/src/js/views/views/LeagueFinances.js
@@ -16,7 +16,10 @@ const LeagueFinances = ({minPayroll, luxuryPayroll, luxuryTax, salaryCap, season
         return {
             key: t.tid,
             data: [
-                <a href={helpers.leagueUrl(["team_finances", t.abbrev])}>{t.region} {t.name}</a>,
+                <span>
+                    <span className="table-logo"><img src={t.imgURL} alt="" /></span>
+                    <a href={helpers.leagueUrl(["team_finances", t.abbrev])}>{t.region} {t.name}</a>
+                </span>,
                 helpers.numberWithCommas(helpers.round(t.att)),
                 helpers.formatCurrency(t.revenue, "M"),
                 helpers.formatCurrency(t.profit, "M"),

--- a/src/js/views/views/Playoffs.js
+++ b/src/js/views/views/Playoffs.js
@@ -1,8 +1,10 @@
 // @flow
 
 import React from 'react';
+import g from '../../globals';
+import * as helpers from '../../util/helpers';
 import bbgmViewReact from '../../util/bbgmViewReact';
-import {Dropdown, JumpTo, NewWindowLink, PlayoffMatchup} from '../components';
+import {Dropdown, JumpTo, NewWindowLink, PlayoffMatchup, PlayoffJumbotron} from '../components';
 
 const Playoffs = ({confNames, finalMatchups, matchups, numPlayoffRounds, season, series}: {
     confNames: string[],
@@ -23,6 +25,84 @@ const Playoffs = ({confNames, finalMatchups, matchups, numPlayoffRounds, season,
 }) => {
     bbgmViewReact.title(`Playoffs - ${season}`);
 
+    const displayChampions = () => {
+        if (series.length === 4 && series[3].length > 0) {
+            const finals = series[3][0];
+            let winnerImg = null;
+            let winnerTid = null;
+
+            if (finals.away.won === 4) {
+                winnerImg = finals.away.imgURL;
+                winnerTid = finals.away.tid;
+            }
+            if (finals.home.won === 4) {
+                winnerImg = finals.home.imgURL;
+                winnerTid = finals.home.tid;
+            }
+
+            if (winnerImg) {
+                return <div className="jumbotron text-center">
+                    <a href={helpers.leagueUrl(["roster", g.teamAbbrevsCache[winnerTid], season])}>
+                        <img height="80" src={winnerImg} alt="" />
+                    </a>
+                    <h2 className={g.userTid === winnerTid && "bg-info"}>{g.teamRegionsCache[winnerTid]} {g.teamNamesCache[winnerTid]}</h2>
+                    <h1>{season} Champions</h1>
+                </div>;
+            }
+
+
+            if (finals.away.imgURL && finals.home.imgURL) {
+                let west = finals.home;
+                let east = finals.away;
+                if (finals.home.cid === 0) {
+                    west = finals.away;
+                    east = finals.home;
+                }
+                return <PlayoffJumbotron season={season} playoffRound="Finals" west={west} east={east} />;
+            }
+        }
+    };
+
+    const displayUserTeam = () => {
+        // Display current series for user team, hide if finals and if the user team is out.
+
+        let currentSeries = null;
+        let currentRound = null;
+
+        if (series.length === 4 && series[3].length > 0) {
+            return; // Do not show this for finals.
+        }
+
+        for (const [index, playoffRound] of [...series].reverse().entries()) {
+            if (index === 0) {
+                continue;
+            }
+            for (const playoffSeries of playoffRound) {
+                if (g.userTid === playoffSeries.home.tid || g.userTid === playoffSeries.away.tid) {
+                    currentSeries = playoffSeries;
+                    currentRound = index;
+                    break;
+                }
+            }
+            if (currentSeries) {
+                break;
+            }
+        }
+
+        if (currentSeries && currentSeries.home.imgURL && currentSeries.away.imgURL) {
+            const west = currentSeries.home;
+            const east = currentSeries.away;
+
+            const playoffRoundNames = {
+                1: "Conference Finals",
+                2: "2nd Round",
+                3: "1st Round",
+            };
+
+            return <PlayoffJumbotron season={season} playoffRound={playoffRoundNames[currentRound]} west={west} east={east} />;
+        }
+    };
+
     return <div>
         <Dropdown view="playoffs" fields={["seasons"]} values={[season]} />
         <JumpTo season={season} />
@@ -31,6 +111,9 @@ const Playoffs = ({confNames, finalMatchups, matchups, numPlayoffRounds, season,
         {!finalMatchups ? <p>This is what the playoff matchups would be if the season ended right now.</p> : null}
 
         {confNames.length === 2 ? <h3 className="hidden-xs">{confNames[1]} <span className="pull-right">{confNames[0]}</span></h3> : null}
+
+        {finalMatchups && displayUserTeam()}
+        {finalMatchups && displayChampions()}
 
         <div className="table-responsive">
             <table className="table-condensed" width="100%">

--- a/src/js/views/views/PowerRankings.js
+++ b/src/js/views/views/PowerRankings.js
@@ -20,7 +20,10 @@ const PowerRankings = ({teams}) => {
                 t.overallRank,
                 performanceRank,
                 t.talentRank,
-                <a href={helpers.leagueUrl(["roster", t.abbrev])}>{t.region} {t.name}</a>,
+                <span>
+                    <span className="table-logo"><img src={t.imgURL} alt="" /></span>
+                    <a href={helpers.leagueUrl(["roster", t.abbrev])}>{t.region} {t.name}</a>
+                </span>,
                 t.won,
                 t.lost,
                 t.lastTen,

--- a/src/js/views/views/Schedule.js
+++ b/src/js/views/views/Schedule.js
@@ -16,8 +16,10 @@ const Schedule = ({abbrev, completed, season, teamInfo, upcoming}) => {
                 <h2>Upcoming Games</h2>
                 <ul className="list-group">
                     {upcoming.map(({gid, teams}) => <li className="list-group-item schedule-row" key={gid}>
+                        <span className="playoff-matchup-logo"><img src={teamInfo[teams[0].tid].imgURL} alt="" /></span>&nbsp;
                         <a href={helpers.leagueUrl(['roster', teams[0].abbrev])}>{teams[0].region}</a> <span className="schedule-extra">({teamInfo[teams[0].tid].won}-{teamInfo[teams[0].tid].lost})</span>
                         <span className="schedule-at"> @ </span>
+                        &nbsp;<span className="playoff-matchup-logo"><img src={teamInfo[teams[1].tid].imgURL} alt="" /></span>&nbsp;
                         <a href={helpers.leagueUrl(['roster', teams[1].abbrev])}>{teams[1].region}</a> <span className="schedule-extra">({teamInfo[teams[1].tid].won}-{teamInfo[teams[1].tid].lost})</span>
                     </li>)}
                 </ul>
@@ -37,8 +39,10 @@ const Schedule = ({abbrev, completed, season, teamInfo, upcoming}) => {
                                     <a href={helpers.leagueUrl(['game_log', abbrev, season, gid])}>{score}{overtime}</a>
                                 </div>
                             </div>
+                            <span className="playoff-matchup-logo"><img src={teamInfo[teams[0].tid].imgURL} alt="" /></span>&nbsp;
                             <a href={helpers.leagueUrl(['roster', teams[0].abbrev])}>{teams[0].region}</a>
                             <span className="schedule-at"> @ </span>
+                            &nbsp;<span className="playoff-matchup-logo"><img src={teamInfo[teams[1].tid].imgURL} alt="" /></span>&nbsp;
                             <a href={helpers.leagueUrl(['roster', teams[1].abbrev])}>{teams[1].region}</a>
                         </li>;
                     })}

--- a/src/js/views/views/Standings.js
+++ b/src/js/views/views/Standings.js
@@ -8,6 +8,7 @@ import clickable from '../wrappers/clickable';
 const DivStandingsRow = clickable(({clicked, season, t, toggleClicked}) => {
     return <tr key={t.tid} className={classNames({info: t.highlight, warning: clicked})} onClick={toggleClicked}>
         <td>
+            <span className="table-logo"><img src={t.imgURL} alt="" /></span>
             <a href={helpers.leagueUrl(['roster', t.abbrev, season])}>{t.region} {t.name}</a>
             <span>{t.playoffsRank ? ` (${t.playoffsRank})` : ''}</span>
         </td>
@@ -70,7 +71,10 @@ const ConfStandings = ({playoffsByConference, season, teams}) => {
         <tbody>
             {teams.map((t, i) => {
                 return <tr key={t.tid} className={classNames({info: t.highlight, separator: i === 7 && playoffsByConference})}>
-                    <td>{t.rank}. <a href={helpers.leagueUrl(['roster', t.abbrev, season])}>{t.region}</a></td>
+                    <td>{t.rank}.
+                        <span className="table-logo"><img src={t.imgURL} alt="" /></span>
+                        <a href={helpers.leagueUrl(['roster', t.abbrev, season])}>{t.region}</a>
+                    </td>
                     <td style={{textAlign: 'right'}}>{t.gb}</td>
                 </tr>;
             })}


### PR DESCRIPTION
- Use the team logos in the playoff brackets, dim the logo of the loser in the matchup.
- Added a jumbotron to highlight current series the user team, the finals and the year's champion.
- Make use of the team logos in team tables 