### PR TITLE
4.0 ratings popover

### DIFF
--- a/src/js/ui/components/PlayerNameLabels.js
+++ b/src/js/ui/components/PlayerNameLabels.js
@@ -4,15 +4,18 @@ import React from 'react';
 import {helpers} from '../../common';
 import SkillsBlock from './SkillsBlock';
 import WatchBlock from './WatchBlock';
+import RatingsPopover from './RatingsPopover';
 import type {PlayerInjury, PlayerSkill} from '../../common/types';
 
-const PlayerNameLabels = ({children, injury, pid, skills, style, watch}: {
+const PlayerNameLabels = ({children, injury, pid, skills, style, watch, ratings, stats}: {
     children: string,
     injury?: PlayerInjury,
     pid: number,
     skills?: PlayerSkill[],
     style?: {[key: string]: string},
     watch?: boolean | Function, // For Firefox's Object.watch
+    ratings?: {},
+    stats?: {},
 }) => {
     let injuryIcon = null;
     if (injury !== undefined) {
@@ -32,6 +35,7 @@ const PlayerNameLabels = ({children, injury, pid, skills, style, watch}: {
         {injuryIcon}
         <SkillsBlock skills={skills} />
         {typeof watch === 'boolean' ? <WatchBlock pid={pid} watch={watch} /> : null}
+        {ratings && <RatingsPopover pid={pid} ratings={ratings} stats={stats} />}
     </span>;
 };
 PlayerNameLabels.propTypes = {
@@ -47,6 +51,8 @@ PlayerNameLabels.propTypes = {
         React.PropTypes.bool,
         React.PropTypes.func, // For Firefox's Object.watch
     ]),
+    ratings: React.PropTypes.object,
+    stats: React.PropTypes.object,
 };
 
 export default PlayerNameLabels;

--- a/src/js/ui/components/RatingsPopover.js
+++ b/src/js/ui/components/RatingsPopover.js
@@ -18,7 +18,7 @@ const RatingsPopover = ({pid, ratings, stats}) => {
     const formatShot = (made, attempt, type) => {
         const f = made.toFixed(1);
         const fa = attempt.toFixed(1);
-        const pct = attempt > 0 ? (made / attempt).toFixed(2) * 100 : 0;
+        const pct = attempt > 0 ? Math.round((made / attempt).toFixed(2) * 100) : 0;
         let color = "";
         if (type === 'fg') {
             color = pct > 45 ? "text-success" : color;
@@ -63,8 +63,10 @@ const RatingsPopover = ({pid, ratings, stats}) => {
                     <span className={colorRating(ratings.reb)}>Reb: {ratings.reb}</span>
                 </div>
             </div>
-            { (stats.fg && stats.fga) &&
+            { (stats && stats.fg !== null && stats.fga !== null && stats.tp !== null && stats.tpa !== null &&
+                stats.ft !== null && stats.fta !== null) &&
                 <div>
+                    <br />
                     <div className="row">
                         <div className="col-xs-4">
                             <b>FG</b><br />

--- a/src/js/ui/components/RatingsPopover.js
+++ b/src/js/ui/components/RatingsPopover.js
@@ -1,0 +1,98 @@
+// @flow
+
+import React from 'react';
+import OverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
+import Popover from 'react-bootstrap/lib/Popover';
+
+const RatingsPopover = ({pid, ratings, stats}) => {
+    const colorRating = (rating) => {
+        if (rating >= 80) {
+            return "text-success";
+        } else if (rating > 30 && rating <= 60) {
+            return "text-warning";
+        } else if (rating <= 30) {
+            return "text-danger";
+        }
+        return "";
+    };
+    const formatShot = (made, attempt, type) => {
+        const f = made.toFixed(1);
+        const fa = attempt.toFixed(1);
+        const pct = attempt > 0 ? (made / attempt).toFixed(2) * 100 : 0;
+        let color = "";
+        if (type === 'fg') {
+            color = pct > 45 ? "text-success" : color;
+            color = pct < 40 ? "text-warning" : color;
+            color = pct < 35 ? "text-danger" : color;
+        } else if (type === 'tp') {
+            color = pct > 40 ? "text-success" : color;
+            color = pct < 35 ? "text-warning" : color;
+            color = pct < 30 ? "text-danger" : color;
+        } else if (type === 'ft') {
+            color = pct > 85 ? "text-success" : color;
+            color = pct < 80 ? "text-warning" : color;
+            color = pct < 60 ? "text-danger" : color;
+        }
+        return <span className={color}>{f}/{fa}/{pct}%</span>;
+    };
+    const popoverPlayerRatings = (
+        <Popover id={`ratings-pop-${pid}`}>
+            <div className="row">
+                <div className="col-xs-4">
+                    <b>Physical</b><br />
+                    <span>Hgt: {ratings.hgt}</span><br />
+                    <span className={colorRating(ratings.stre)}>Str: {ratings.stre}</span><br />
+                    <span className={colorRating(ratings.spd)}>Spd: {ratings.spd}</span><br />
+                    <span className={colorRating(ratings.jmp)}>Jmp: {ratings.jmp}</span><br />
+                    <span className={colorRating(ratings.endu)}>End: {ratings.endu}</span>
+                </div>
+                <div className="col-xs-4">
+                    <b>Shooting</b><br />
+                    <span className={colorRating(ratings.ins)}>Ins: {ratings.ins}</span><br />
+                    <span className={colorRating(ratings.dnk)}>Dnk: {ratings.dnk}</span><br />
+                    <span className={colorRating(ratings.ft)}>Ft: {ratings.ft}</span><br />
+                    <span className={colorRating(ratings.fg)}>2Pt: {ratings.fg}</span><br />
+                    <span className={colorRating(ratings.tp)}>3Pt: {ratings.tp}</span>
+                </div>
+                <div className="col-xs-4">
+                    <b>Skill</b><br />
+                    <span className={colorRating(ratings.blk)}>Blk: {ratings.blk}</span><br />
+                    <span className={colorRating(ratings.stl)}>Stl: {ratings.stl}</span><br />
+                    <span className={colorRating(ratings.drb)}>Drb: {ratings.drb}</span><br />
+                    <span className={colorRating(ratings.pss)}>Pss: {ratings.pss}</span><br />
+                    <span className={colorRating(ratings.reb)}>Reb: {ratings.reb}</span>
+                </div>
+            </div>
+            { (stats.fg && stats.fga) &&
+                <div>
+                    <div className="row">
+                        <div className="col-xs-4">
+                            <b>FG</b><br />
+                            {formatShot(stats.fg, stats.fga, 'fg')}
+                        </div>
+                        <div className="col-xs-4">
+                            <b>3PT</b><br />
+                            <span>{formatShot(stats.tp, stats.tpa, 'tp')}</span>
+                        </div>
+                        <div className="col-xs-4">
+                            <b>FT</b><br />
+                            <span>{formatShot(stats.ft, stats.fta, 'ft')}</span>
+                        </div>
+                    </div>
+                </div>
+                || null
+            }
+        </Popover>
+    );
+
+    return <OverlayTrigger trigger="click" rootClose placement="right" overlay={popoverPlayerRatings}>
+        <span className="glyphicon glyphicon-th watch" aria-hidden="true" />
+    </OverlayTrigger>;
+};
+RatingsPopover.propTypes = {
+    pid: React.PropTypes.number,
+    ratings: React.PropTypes.object,
+    stats: React.PropTypes.object,
+};
+
+export default RatingsPopover;

--- a/src/js/ui/views/Draft.js
+++ b/src/js/ui/views/Draft.js
@@ -75,7 +75,7 @@ class Draft extends React.Component {
 
         const rowsUndrafted = undrafted.map(p => {
             const data = [
-                <PlayerNameLabels pid={p.pid} injury={p.injury} skills={p.ratings.skills} watch={p.watch}>{p.name}</PlayerNameLabels>,
+                <PlayerNameLabels pid={p.pid} injury={p.injury} skills={p.ratings.skills} watch={p.watch} ratings={p.ratings}>{p.name}</PlayerNameLabels>,
                 p.ratings.pos,
                 p.age,
                 p.ratings.ovr,
@@ -104,7 +104,7 @@ class Draft extends React.Component {
             const data = [
                 `${p.draft.round}-${p.draft.pick}`,
                 <DraftAbbrev originalTid={p.draft.originalTid} season={g.season} tid={p.draft.tid}>{p.draft.tid} {p.draft.originalTid}</DraftAbbrev>,
-                p.pid >= 0 ? <PlayerNameLabels pid={p.pid} injury={p.injury} skills={p.ratings.skills} watch={p.watch}>{p.name}</PlayerNameLabels> : null,
+                p.pid >= 0 ? <PlayerNameLabels pid={p.pid} injury={p.injury} skills={p.ratings.skills} watch={p.watch} ratings={p.ratings}>{p.name}</PlayerNameLabels> : null,
                 p.pid >= 0 ? p.ratings.pos : null,
                 p.pid >= 0 ? p.age : null,
                 p.pid >= 0 ? p.ratings.ovr : null,

--- a/src/js/ui/views/DraftScouting.js
+++ b/src/js/ui/views/DraftScouting.js
@@ -58,6 +58,7 @@ class DraftScouting extends React.Component {
                                     pid={p.pid}
                                     skills={p.skills}
                                     watch={p.watch}
+                                    ratings={p.ratings}
                                 >{p.name}</PlayerNameLabels>,
                                 p.pos,
                                 p.age,

--- a/src/js/ui/views/FreeAgents.js
+++ b/src/js/ui/views/FreeAgents.js
@@ -34,6 +34,8 @@ const FreeAgents = ({capSpace, gamesInProgress, minContract, numRosterSpots, pha
                     injury={p.injury}
                     skills={p.ratings.skills}
                     watch={p.watch}
+                    ratings={p.ratings}
+                    stats={p.stats}
                 >{p.name}</PlayerNameLabels>,
                 p.ratings.pos,
                 p.age,

--- a/src/js/ui/views/NegotiationList.js
+++ b/src/js/ui/views/NegotiationList.js
@@ -26,6 +26,8 @@ const NegotiationList = ({players}) => {
                     injury={p.injury}
                     skills={p.ratings.skills}
                     watch={p.watch}
+                    ratings={p.ratings}
+                    stats={p.stats}
                 >{p.name}</PlayerNameLabels>,
                 p.ratings.pos,
                 p.age,

--- a/src/js/ui/views/Roster.js
+++ b/src/js/ui/views/Roster.js
@@ -156,6 +156,8 @@ const RosterRow = clickable(props => {
                 injury={p.injury}
                 skills={p.ratings.skills}
                 watch={p.watch}
+                ratings={p.ratings}
+                stats={p.stats}
             >{p.name}</PlayerNameLabels>
         </td>
         <td onClick={toggleClicked}>{p.ratings.pos}</td>

--- a/src/js/ui/views/Trade.js
+++ b/src/js/ui/views/Trade.js
@@ -10,7 +10,7 @@ const genRows = (players, handleChangeAsset) => {
             key: p.pid,
             data: [
                 <input type="checkbox" value={p.pid} title={p.untradableMsg} checked={p.selected} disabled={p.untradable} onChange={() => handleChangeAsset(p.pid)} />,
-                <PlayerNameLabels injury={p.injury} pid={p.pid} skills={p.ratings.skills} watch={p.watch}>{p.name}</PlayerNameLabels>,
+                <PlayerNameLabels injury={p.injury} pid={p.pid} skills={p.ratings.skills} watch={p.watch} ratings={p.ratings} stats={p.stats}>{p.name}</PlayerNameLabels>,
                 p.ratings.pos,
                 p.age,
                 p.ratings.ovr,

--- a/src/js/ui/views/TradingBlock.js
+++ b/src/js/ui/views/TradingBlock.js
@@ -12,6 +12,8 @@ const OfferPlayerRow = clickable(({clicked, p, toggleClicked}) => {
                 pid={p.pid}
                 skills={p.ratings.skills}
                 watch={p.watch}
+                ratings={p.ratings}
+                stats={p.stats}
             >{p.name}</PlayerNameLabels>
         </td>
         <td>{p.ratings.pos}</td>
@@ -197,6 +199,8 @@ class TradingBlock extends React.Component {
                         pid={p.pid}
                         skills={p.ratings.skills}
                         watch={p.watch}
+                        ratings={p.ratings}
+                        stats={p.stats}
                     >{p.name}</PlayerNameLabels>,
                     p.ratings.pos,
                     p.age,

--- a/src/js/ui/views/UpcomingFreeAgents.js
+++ b/src/js/ui/views/UpcomingFreeAgents.js
@@ -17,6 +17,8 @@ const UpcomingFreeAgents = ({players, season}) => {
                     pid={p.pid}
                     skills={p.ratings.skills}
                     watch={p.watch}
+                    ratings={p.ratings}
+                    stats={p.stats}
                 >{p.name}</PlayerNameLabels>,
                 p.ratings.pos,
                 p.age,

--- a/src/js/ui/views/WatchList.js
+++ b/src/js/ui/views/WatchList.js
@@ -50,7 +50,7 @@ class WatchList extends React.Component {
             return {
                 key: p.pid,
                 data: [
-                    <PlayerNameLabels injury={p.injury} pid={p.pid} skills={p.ratings.skills} watch={p.watch}>{p.name}</PlayerNameLabels>,
+                    <PlayerNameLabels injury={p.injury} pid={p.pid} skills={p.ratings.skills} watch={p.watch} ratings={p.ratings} stats={p.stats}>{p.name}</PlayerNameLabels>,
                     p.ratings.pos,
                     p.age,
                     <a href={helpers.leagueUrl(["roster", p.abbrev])}>{p.abbrev}</a>,

--- a/src/js/worker/api/index.js
+++ b/src/js/worker/api/index.js
@@ -324,8 +324,10 @@ const getTradingBlockOffers = async (pids: number[], dpids: number[]) => {
             players = players.filter(p => offers[i].pids.includes(p.pid));
             players = await idb.getCopies.playersPlus(players, {
                 attrs: ["pid", "name", "age", "contract", "injury", "watch"],
-                ratings: ["ovr", "pot", "skills", "pos"],
-                stats: ["min", "pts", "trb", "ast", "per"],
+                ratings: ["ovr", "pot", "skills", "pos", "hgt", "stre", "spd",
+                    "jmp", "endu", "ins", "dnk", "ft", "fg", "tp", "blk", "stl", "drb", "pss", "reb"],
+                stats: ["min", "pts", "trb", "ast", "per",
+                    "fg", "fga", "tp", "tpa", "ft", "fta"],
                 season: g.season,
                 tid,
                 showNoStats: true,

--- a/src/js/worker/views/draft.js
+++ b/src/js/worker/views/draft.js
@@ -25,7 +25,9 @@ async function updateDraft(): void | {[key: string]: any} {
     undrafted.sort((a, b) => b.valueFuzz - a.valueFuzz);
     undrafted = await idb.getCopies.playersPlus(undrafted, {
         attrs: ["pid", "name", "age", "injury", "contract", "watch"],
-        ratings: ["ovr", "pot", "skills", "pos"],
+        ratings: ["ovr", "pot", "skills", "pos", "hgt", "stre", "spd",
+            "jmp", "endu", "ins", "dnk", "ft", "fg", "tp", "blk", "stl",
+            "drb", "pss", "reb"],
         stats: ["per", "ewa"],
         season: g.season,
         showNoStats: true,
@@ -38,7 +40,8 @@ async function updateDraft(): void | {[key: string]: any} {
     drafted.sort((a, b) => (100 * a.draft.round + a.draft.pick) - (100 * b.draft.round + b.draft.pick));
     drafted = await idb.getCopies.playersPlus(drafted, {
         attrs: ["pid", "tid", "name", "age", "draft", "injury", "contract", "watch"],
-        ratings: ["ovr", "pot", "skills", "pos"],
+        ratings: ["ovr", "pot", "skills", "pos", "hgt", "stre", "spd",
+            "jmp", "endu", "ins", "dnk", "ft", "fg", "tp", "blk", "stl", "drb", "pss", "reb"],
         stats: ["per", "ewa"],
         season: g.season,
         showRookies: true,

--- a/src/js/worker/views/draftScouting.js
+++ b/src/js/worker/views/draftScouting.js
@@ -9,7 +9,9 @@ async function addSeason(season, tid) {
 
     playersAll = await idb.getCopies.playersPlus(playersAll, {
         attrs: ["pid", "firstName", "lastName", "age", "watch", "valueFuzz"],
-        ratings: ["ovr", "pot", "skills", "fuzz", "pos"],
+        ratings: ["ovr", "pot", "skills", "fuzz", "pos", "hgt", "stre", "spd",
+            "jmp", "endu", "ins", "dnk", "ft", "fg", "tp", "blk", "stl",
+            "drb", "pss", "reb"],
         showNoStats: true,
         showRookies: true,
         fuzz: true,
@@ -36,6 +38,7 @@ async function addSeason(season, tid) {
             pot: pa.ratings[0].pot,
             skills: pa.ratings[0].skills,
             pos: pa.ratings[0].pos,
+            ratings: pa.ratings[0],
 
             rank: i + 1,
         });

--- a/src/js/worker/views/freeAgents.js
+++ b/src/js/worker/views/freeAgents.js
@@ -16,8 +16,11 @@ async function updateFreeAgents(): void | {[key: string]: any} {
 
     players = await idb.getCopies.playersPlus(players, {
         attrs: ["pid", "name", "age", "contract", "freeAgentMood", "injury", "watch"],
-        ratings: ["ovr", "pot", "skills", "pos"],
-        stats: ["min", "pts", "trb", "ast", "per"],
+        ratings: ["ovr", "pot", "skills", "pos", "hgt", "stre", "spd",
+            "jmp", "endu", "ins", "dnk", "ft", "fg", "tp", "blk", "stl",
+            "drb", "pss", "reb"],
+        stats: ["min", "pts", "trb", "ast", "per",
+            "fg", "fga", "tp", "tpa", "ft", "fta"],
         season: g.season,
         showNoStats: true,
         showRookies: true,

--- a/src/js/worker/views/negotiationList.js
+++ b/src/js/worker/views/negotiationList.js
@@ -15,8 +15,11 @@ async function updateNegotiationList(): void | {[key: string]: any} {
     players = players.filter(p => negotiationPids.includes(p.pid));
     players = await idb.getCopies.playersPlus(players, {
         attrs: ["pid", "name", "age", "freeAgentMood", "injury", "watch"],
-        ratings: ["ovr", "pot", "skills", "pos"],
-        stats: ["min", "pts", "trb", "ast", "per"],
+        ratings: ["ovr", "pot", "skills", "pos", "hgt", "stre", "spd",
+            "jmp", "endu", "ins", "dnk", "ft", "fg", "tp", "blk", "stl",
+            "drb", "pss", "reb"],
+        stats: ["min", "pts", "trb", "ast", "per",
+            "fg", "fga", "tp", "tpa", "ft", "fta"],
         season: g.season,
         tid: g.userTid,
         showNoStats: true,

--- a/src/js/worker/views/roster.js
+++ b/src/js/worker/views/roster.js
@@ -27,8 +27,10 @@ async function updateRoster(
         });
 
         const attrs = ["pid", "tid", "draft", "name", "age", "contract", "cashOwed", "rosterOrder", "injury", "ptModifier", "watch", "gamesUntilTradable"];  // tid and draft are used for checking if a player can be released without paying his salary
-        const ratings = ["ovr", "pot", "dovr", "dpot", "skills", "pos"];
-        const stats = ["gp", "min", "pts", "trb", "ast", "per", "yearsWithTeam"];
+        const ratings = ["ovr", "pot", "dovr", "dpot", "skills", "pos", "hgt", "stre", "spd",
+            "jmp", "endu", "ins", "dnk", "ft", "fg", "tp", "blk", "stl", "drb", "pss", "reb"];
+        const stats = ["gp", "min", "pts", "trb", "ast", "per", "yearsWithTeam",
+            "fg", "fga", "tp", "tpa", "ft", "fta"];
 
         if (inputs.season === g.season) {
             // Show players currently on the roster

--- a/src/js/worker/views/trade.js
+++ b/src/js/worker/views/trade.js
@@ -54,8 +54,9 @@ async function updateTrade(): void | {[key: string]: any} {
     const userPicks: any = await idb.cache.draftPicks.indexGetAll('draftPicksByTid', g.userTid);
 
     const attrs = ["pid", "name", "age", "contract", "injury", "watch", "gamesUntilTradable"];
-    const ratings = ["ovr", "pot", "skills", "pos"];
-    const stats = ["min", "pts", "trb", "ast", "per"];
+    const ratings = ["ovr", "pot", "skills", "pos", "hgt", "stre", "spd",
+        "jmp", "endu", "ins", "dnk", "ft", "fg", "tp", "blk", "stl", "drb", "pss", "reb"];
+    const stats = ["min", "pts", "trb", "ast", "per", "fg", "fga", "tp", "tpa", "ft", "fta"];
 
     userRoster = await idb.getCopies.playersPlus(userRoster, {
         attrs,

--- a/src/js/worker/views/tradingBlock.js
+++ b/src/js/worker/views/tradingBlock.js
@@ -17,8 +17,10 @@ async function updateUserRoster(
 
         userRoster = await idb.getCopies.playersPlus(userRoster, {
             attrs: ["pid", "name", "age", "contract", "injury", "watch", "gamesUntilTradable"],
-            ratings: ["ovr", "pot", "skills", "pos"],
-            stats: ["min", "pts", "trb", "ast", "per"],
+            ratings: ["ovr", "pot", "skills", "pos", "hgt", "stre", "spd",
+                "jmp", "endu", "ins", "dnk", "ft", "fg", "tp", "blk", "stl", "drb", "pss", "reb"],
+            stats: ["min", "pts", "trb", "ast", "per",
+                "fg", "fga", "tp", "tpa", "ft", "fta"],
             season: g.season,
             tid: g.userTid,
             showNoStats: true,

--- a/src/js/worker/views/upcomingFreeAgents.js
+++ b/src/js/worker/views/upcomingFreeAgents.js
@@ -20,8 +20,10 @@ async function updateUpcomingFreeAgents(
 
     players = await idb.getCopies.playersPlus(players, {
         attrs: ["pid", "name", "age", "contract", "freeAgentMood", "injury", "watch", "contractDesired"],
-        ratings: ["ovr", "pot", "skills", "pos"],
-        stats: ["min", "pts", "trb", "ast", "per"],
+        ratings: ["ovr", "pot", "skills", "pos", "hgt", "stre", "spd",
+            "jmp", "endu", "ins", "dnk", "ft", "fg", "tp", "blk", "stl", "drb", "pss", "reb"],
+        stats: ["min", "pts", "trb", "ast", "per",
+            "fg", "fga", "tp", "tpa", "ft", "fta"],
         season: g.season,
         showNoStats: true,
         showRookies: true,

--- a/src/js/worker/views/watchList.js
+++ b/src/js/worker/views/watchList.js
@@ -18,8 +18,10 @@ async function updatePlayers(
         players = players.filter(p => p.watch && typeof p.watch !== "function"); // In Firefox, objects have a "watch" function
         players = await idb.getCopies.playersPlus(players, {
             attrs: ["pid", "name", "age", "injury", "tid", "abbrev", "watch", "contract", "freeAgentMood", "draft"],
-            ratings: ["ovr", "pot", "skills", "pos"],
-            stats: ["gp", "min", "fgp", "tpp", "ftp", "trb", "ast", "tov", "stl", "blk", "pts", "per", "ewa"],
+            ratings: ["ovr", "pot", "skills", "pos", "hgt", "stre", "spd",
+                "jmp", "endu", "ins", "dnk", "ft", "fg", "tp", "blk", "stl", "drb", "pss", "reb"],
+            stats: ["gp", "min", "fgp", "tpp", "ftp", "trb", "ast", "tov", "stl", "blk", "pts", "per", "ewa",
+                "fg", "fga", "tp", "tpa", "ft", "fta"],
             season: g.season,
             statType: inputs.statType,
             playoffs: inputs.playoffs === "playoffs",


### PR DESCRIPTION
So I was playing with the beta (so fast!) and was missing this feature so I've ported it.
- Ported PR to 4.0 codebase
- Added display of shooting stats (not displayed if no stat i.e. new season or undrafted)

Have not made  changes for:

> - On any player listed in a table, click the ratings icon and the row gets highlighted, same as if you click elsewhere in the row. But if you click the "Watch" flag, this doesn't happen. The magic preventing that is in js/views/wrappers/clickable.js. The problem is that the ratings icon is a SPAN tag, which is not on the blacklist of tag names for highlighting. This could be modified to look for a data- element or something on this tag. Or maybe a less hacky approach for this problem in general.
> 
> - colorRating should be used on player pages too.

^ Not sure what file to use for shared colorRating