### PR TITLE
Show currency in billions

### DIFF
--- a/src/js/common/helpers.js
+++ b/src/js/common/helpers.js
@@ -243,6 +243,11 @@ function formatCurrency(amount: number, append: string = '', precision: number =
     if (amount < 0) {
         return `-$${Math.abs(amount).toFixed(precision)}${append}`;
     }
+    if (append === 'M' && amount > 1000) {
+        amount /= 1000;
+        append = 'B';
+        precision *= 2;
+    }
     return `$${amount.toFixed(precision)}${append}`;
 }
 

--- a/src/js/ui/components/DataTable.js
+++ b/src/js/ui/components/DataTable.js
@@ -188,6 +188,9 @@ const getSortVal = (value = null, sortType) => {
                 return -Infinity;
             }
             // Drop $ and parseFloat will just keep the numeric part at the beginning of the string
+            if (sortVal.includes('B')) {
+                return parseFloat(sortVal.replace('$', '')) * 1000;
+            }
             return parseFloat(sortVal.replace('$', ''));
         }
         return sortVal;


### PR DESCRIPTION
Display greater than 1000 millions in billions i.e. League Finance team cash and team finance cash.
Handled sorting in data table.