### PR TITLE
AI teams keep good first rounders "Restricted Free Agency"

### DIFF
--- a/src/js/worker/core/contractNegotiation.js
+++ b/src/js/worker/core/contractNegotiation.js
@@ -42,7 +42,8 @@ async function create(pid: number, resigning: boolean, tid: number = g.userTid):
         playerYears += 1;
     }
 
-    if (helpers.refuseToNegotiate(playerAmount, p.freeAgentMood[g.userTid])) {
+    const isFirstRounder = p.draft.round === 1 && p.draft.year === g.season - 3;
+    if (!isFirstRounder && helpers.refuseToNegotiate(playerAmount, p.freeAgentMood[g.userTid])) {
         return `<a href="${helpers.leagueUrl(["player", p.pid])}">${p.firstName} ${p.lastName}</a> refuses to sign with you, no matter what you offer.`;
     }
 

--- a/src/js/worker/core/phase.js
+++ b/src/js/worker/core/phase.js
@@ -446,7 +446,15 @@ async function newPhaseFreeAgency(conditions: Conditions) {
             // Automatically negotiate with teams
             const factor = strategies[p.tid] === "rebuilding" ? 0.4 : 0;
 
-            if (Math.random() < p.value / 100 - factor) { // Should eventually be smarter than a coin flip
+            const isFirstRounder = p.draft.round === 1 && p.draft.year === g.season - 3;
+            let ewa = 0;
+            if (isFirstRounder) {
+                let playerStats = await idb.getCopies.playerStats({pid: p.pid});
+                playerStats = playerStats.filter(ps => ps.season === g.season - 1);
+                ewa = playerStats.reduce((acc, ps) => acc + ps.ewa, 0);
+            }
+
+            if (Math.random() < p.value / 100 - factor || (isFirstRounder && ewa > 1)) { // Should eventually be smarter than a coin flip
                 // See also core.team
                 const contract = player.genContract(p);
                 contract.exp += 1; // Otherwise contracts could expire this season

--- a/src/js/worker/core/phase.js
+++ b/src/js/worker/core/phase.js
@@ -450,7 +450,7 @@ async function newPhaseFreeAgency(conditions: Conditions) {
             let ewa = 0;
             if (isFirstRounder) {
                 let playerStats = await idb.getCopies.playerStats({pid: p.pid});
-                playerStats = playerStats.filter(ps => ps.season === g.season - 1);
+                playerStats = playerStats.filter(ps => ps.season === g.season);
                 ewa = playerStats.reduce((acc, ps) => acc + ps.ewa, 0);
             }
 


### PR DESCRIPTION
Opening this one up for discussion as a suggested solution to a minor issue in TODO:
- Make good young players much less likely to become FAs

Gist:
This is similar to the current NBA CBA wherein first rounders can't really be a FA after their first contract because their drafting team can match any offer they receive (Restricted Free Agency). Resulting in good young players staying with their original teams for the first 6 or 7 years.

This change implements the above by making AI teams automatically re-sign their good first rounders. Currently a good first rounder should have an EWA > 1 on their last season and has an expiring rookie contract. 

Gameplay-wise this lessens star players being available on the market (much like IRL), also makes them older when they do become available. So instead of signing a 22-25 year old 70+ovr, your signing 24-27 year old 70+ovr player. 

This makes the game somewhat harder, but it just might be too easy right now when you don't really need to win the draft lottery to get young star players. What do you think?

A randomization factor can be introduced so that this will not occur 100% of the time to emulate real life cases like players threatening to play overseas unless released (but they don't really do that in current NBA).