### PR TITLE
Change text color on notifications for game results

### DIFF
--- a/src/css/bbgm-notifications.scss
+++ b/src/css/bbgm-notifications.scss
@@ -36,6 +36,14 @@
   }
 }
 
+.notification-won {
+  color: #00ff00;
+}
+
+.notification-lost {
+  color: #ff0000;
+}
+
 .notification-fadein {
   // This transition is for the hover, not original fade in
   transition: opacity .25s ease-in-out;

--- a/src/js/worker/core/game.js
+++ b/src/js/worker/core/game.js
@@ -353,6 +353,7 @@ async function writeGameStats(results: GameResults, att: number, conditions: Con
         logEvent({
             type: results.team[tw].id === g.userTid ? "gameWon" : "gameLost",
             text,
+            extraClass: results.team[tw].id === g.userTid ? "notification-won" : "notification-lost",
             saveToDb: false,
             tids: [results.team[0].id, results.team[1].id],
         }, conditions);


### PR DESCRIPTION
When the notifications are streaming by quickly in the bottom right it's hard to see whether your team is winning or losing.  I changed the text color so that it is green for a win, red for a loss.  Example picture attached.

Note: I don't do much JS - so feedback is welcome.

![screen shot 2017-08-04 at 1 16 44 am](https://user-images.githubusercontent.com/2279506/28956490-de897fb8-78b2-11e7-8bd1-ff4bafd3726c.png)
