### PR TITLE
During playoffs, add play "Through round" option

### DIFF
--- a/src/js/worker/api/actions.js
+++ b/src/js/worker/api/actions.js
@@ -138,6 +138,17 @@ const playMenu = {
         }
     },
 
+    throughRound: async (conditions: Conditions) => {
+	if (g.phase === PHASE.PLAYOFFS) {
+	    const playoffSeries = await idb.cache.playoffSeries.get(g.season);
+
+            const series = playoffSeries.series[playoffSeries.currentRound][0];
+            const numDaysThisSeries = 7 - series.home.won - series.away.won;
+
+            game.play(numDaysThisSeries, conditions);
+        }
+    },
+
     throughPlayoffs: async (conditions: Conditions) => {
         if (g.phase === PHASE.PLAYOFFS) {
             await updateStatus('Playing...'); // For quick UI updating, before await

--- a/src/js/worker/util/updatePlayMenu.js
+++ b/src/js/worker/util/updatePlayMenu.js
@@ -25,6 +25,7 @@ const updatePlayMenu = async () => {
         week: {label: "One week"},
         month: {label: "One month"},
         untilPlayoffs: {label: "Until playoffs"},
+	throughRound: {label: "Through round"},
         throughPlayoffs: {label: "Through playoffs"},
         dayLive: {url: helpers.leagueUrl(["live"]), label: "One day (live)"},
         viewDraftLottery: {url: helpers.leagueUrl(["draft_lottery"]), label: "View draft lottery"},
@@ -54,7 +55,7 @@ const updatePlayMenu = async () => {
         keys = ["day", "dayLive", "week", "month", "untilPlayoffs"];
     } else if (g.phase === PHASE.PLAYOFFS) {
         // Playoffs
-        keys = ["day", "dayLive", "week", "month", "throughPlayoffs"];
+        keys = ["day", "dayLive", "throughRound", "throughPlayoffs"];
     } else if (g.phase === PHASE.DRAFT_LOTTERY) {
         // Offseason - pre draft
         keys = ["viewDraftLottery", "untilDraft"];


### PR DESCRIPTION
During playoffs it doesn't make sense to play "One week" or "One month" (not to me at least).  So I replaced those options with play "Through round".

![screen shot 2017-08-04 at 2 21 37 pm](https://user-images.githubusercontent.com/2279506/28983635-449ad7ee-7920-11e7-8b24-cdb5b18db689.png)
