### PR TITLE
Repeater tax multiplier

### DIFF
--- a/src/js/common/types.js
+++ b/src/js/common/types.js
@@ -635,6 +635,12 @@ type BudgetItem = {|
     rank: number,
 |};
 
+type TaxItem = {|
+    amount: number,
+    rank: number,
+    repeaterMultiplier: number,
+|};
+
 export type TeamSeason = {|
     tid: number,
     season: number,
@@ -668,8 +674,8 @@ export type TeamSeason = {|
     |},
     expenses: {|
         salary: BudgetItem,
-        luxuryTax: BudgetItem,
-        minTax: BudgetItem,
+        luxuryTax: TaxItem,
+        minTax: TaxItem,
         scouting: BudgetItem,
         coaching: BudgetItem,
         health: BudgetItem,

--- a/src/js/worker/core/team/genSeasonRow.js
+++ b/src/js/worker/core/team/genSeasonRow.js
@@ -61,10 +61,12 @@ const genSeasonRow = (tid: number, prevSeason?: TeamSeason): TeamSeason => {
             luxuryTax: {
                 amount: 0,
                 rank: 15.5,
+                repeaterMultiplier: 1.0,
             },
             minTax: {
                 amount: 0,
                 rank: 15.5,
+                repeaterMultiplier: 1.0,
             },
             scouting: {
                 amount: 0,
@@ -92,6 +94,10 @@ const genSeasonRow = (tid: number, prevSeason?: TeamSeason): TeamSeason => {
         newSeason.stadiumCapacity = prevSeason.stadiumCapacity;
         newSeason.hype = prevSeason.hype;
         newSeason.cash = prevSeason.cash;
+        newSeason.expenses.luxuryTax.repeaterMultiplier =
+            prevSeason.expenses.luxuryTax.repeaterMultiplier;
+        newSeason.expenses.minTax.repeaterMultiplier =
+            prevSeason.expenses.minTax.repeaterMultiplier;
     }
 
     return newSeason;


### PR DESCRIPTION
This PR would add a repeater tax multiplier penalty for teams that are above the luxury tax threshold (or below the minimum payroll threshold) for multiple years. The repeater tax multiplier is currently set to increment by 1 for every year a team is in violation of the threshold with a maximum possible multiplier of 5. Once a team has a season with a payroll that is within the payroll limits, its repeater tax multiplier goes back to 1.

An initial thought I have is that it may be better for these parameters to be configurable by the user. If this is a feature you'd like to add let me know and I can make any improvements necessary!