### PR TITLE
change TP% to 3P% on WatchList for consistency

### DIFF
--- a/src/js/ui/util/getCols.js
+++ b/src/js/ui/util/getCols.js
@@ -445,11 +445,6 @@ const cols: {
         desc: "Talent",
         sortType: "number",
     },
-    "TP%": {
-        desc: "Three Point Percentage",
-        sortSequence: ["desc", "asc"],
-        sortType: "number",
-    },
     TRB: {
         desc: "Total Rebounds",
         sortSequence: ["desc", "asc"],

--- a/src/js/ui/views/WatchList.js
+++ b/src/js/ui/views/WatchList.js
@@ -50,7 +50,7 @@ class WatchList extends React.Component {
             "G",
             "Min",
             "FG%",
-            "TP%",
+            "3P%",
             "FT%",
             "Reb",
             "Ast",


### PR DESCRIPTION
Hey, this is my first PR so I have absolutely no clue if I'm doing anything wrong.

Just noticed that there was an inconsistency between how the Watch List labelled 3-Point Percentage in the player stats table (it labelled it as TP%). I ran all tests and it did't break anything, and the linter was OK too.

It's a pretty minor change but I'm pretty new to this, so let me know if I missed anything. Thanks!